### PR TITLE
Support ActiveSupport::TaggedLogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Into this:
 ```
 
 It does the same for `http requests`, `sql queries`, `exceptions`, `template renderings`,
-and any other event your framework logs. (for a full list see `Timber::Events`)
+and any other event your framework logs. (for a full list see [`Timber::Events`](lib/timber/events))
 
 
 ## Logging Custom Events
@@ -101,7 +101,7 @@ end
 Logger.warn PaymentRejectedEvent.new("abcd1234", 100, "Card expired")
 ```
 
-(for more examples, see the `Timber::Logger` docs)
+(for more examples, see [the `Timber::Logger` docs](lib/timber/logger.rb))
 
 No mention of Timber anywhere! In fact, this approach pushes things the opposite way. What if,
 as a result of structured logging, you could start decoupling other services from your application?
@@ -185,6 +185,19 @@ after you add your application.
 
 
 *Other transport methods coming soon!*
+
+
+#### Rails TaggedLogging?
+
+No probs! Use it as normal, Timber will even pull out the tags and include them in the `context`.
+
+```ruby
+config.logger = ActiveSupport::TaggedLogging.new(Timber::Logger.new(STDOUT))
+```
+
+**Warning**: Tags lack meaningful descriptions, they are a poor mans context. Not to worry though!
+Timber provides a simple system for adding custom context that you can optionally use. Checkout
+[the `Timber::CurrentContext` docs](lib/timber/current_context.rb) for examples.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ Timber automatically structures your logs with events and context in a non-propr
 It’s simple, quick, managed, and has absolutely no risk of code debt or lock-in.
 It’s just good ol’ logging.
 
-Timber’s philosophy is that application insight should be open and owned by you.
-And there is no better vehicle than logging:
+Timber’s philosophy is that application insight data should be open and owned by you.
+And there is no better, or more complete, vehicle than logging:
 
 1. It’s a shared practice that has been around since the dawn of computers.
 2. It’s baked into every language, library, and framework. Even your own apps.
 3. The data is entirely owned by you.
 
-The problem is that logs are messy, noisy, and hard to use. Timber solves this by being
+The problem is that logs are unstructured, noisy, and hard to use. Timber solves this by being
 application aware, properly structuring your logs, and optionally providing a [fast, modern,
-and beautiful console](https://timber.io) -- allowing you to realize the power of
-your logs.
+and beautiful console](https://timber.io) -- allowing you to easily, and sanely, realize the
+power of your logs.
 
 
 ## How does it work?

--- a/README.md
+++ b/README.md
@@ -11,21 +11,37 @@
 
 
 1. [What is timber?](#what-is-timber)
-1. [How does it work?](#what-is-timber)
-2. [Logging Custom Events](#logging-custom-events)
-3. [The Timber Console / Pricing](#the-timber-console-pricing)
-2. [Install](#install)
+2. [Why timber?](#why-timber)
+3. [How does it work?](#how-does-it-work)
+4. [Logging Custom Events](#logging-custom-events)
+5. [The Timber Console / Pricing](#the-timber-console-pricing)
+6. [Install](#install)
 
 
 ## What is Timber?
 
-Timber automatically structures your logs with events and context in a non-proprietary JSON format.
-It’s simple, quick, managed, and has absolutely no risk of code debt or lock-in.
-It’s just good ol’ logging.
+Timber takes a different approach to logging, in that it automatically enriches and structures your
+logs without altering the essence of your original log messages. Giving you the best of
+both worlds: human readable logs *and* rich structured data.
+
+More importantly, it does so with absolutely no lock-in or risk of code debt. It's just good
+ol' logging! For example:
+
+1. The resulting log format, by deafult, is a simple, non-proprietary, JSON structure.
+   (see [How does it work?](#how-does-it-work) for an example).
+2. The `Timber::Logger` class extends `Logger`, and will never change the public API. If you opt
+   to stop using Timber, your old `Logger` can be swapped in seamlessly.
+3. Where you send your logs is entirely up to you, but we hope you'll check out
+   [timber.io](https://timber.io). We've built a beautiful, modern, and fast console for searching
+   and visualizing your logs. And because we wrote this library, the interface can make assumptions
+   about the structure of your data. Making the console really nice to use.
+
+
+## Why Timber?
 
 Timber’s philosophy is that application insight should be open and owned by you. It should not
 require a myriad of services to accomplish. And there is no better, or more complete, vehicle
-than logging to solve this:
+than logging:
 
 1. It’s a shared practice that has been around since the dawn of computers.
 2. It’s baked into every language, library, and framework. Even your own apps.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ For more details checkout out [timber.io](https://timber.io).
 
 ```ruby
 # Gemfile
-gem 'timberio'
+gem 'timber'
 ```
 
 ### 2. Install the logger:

--- a/lib/timber/context.rb
+++ b/lib/timber/context.rb
@@ -2,8 +2,14 @@ module Timber
   # Base class for all `Timber::Contexts::*` classes.
   # @private
   class Context
+    class << self
+      def keyspace
+        @keyspace || raise(NotImplementedError.new)
+      end
+    end
+
     def keyspace
-      raise NoImplementedError.new
+      self.class.keyspace
     end
 
     def as_json(options = {})

--- a/lib/timber/contexts.rb
+++ b/lib/timber/contexts.rb
@@ -1,6 +1,7 @@
 require "timber/contexts/custom"
 require "timber/contexts/http"
 require "timber/contexts/organization"
+require "timber/contexts/tags"
 require "timber/contexts/user"
 
 module Timber

--- a/lib/timber/contexts/custom.rb
+++ b/lib/timber/contexts/custom.rb
@@ -8,15 +8,13 @@ module Timber
     #     # ... anything logged here will have the context ...
     #   end
     class Custom < Context
+      @keyspace = :custom
+
       attr_reader :type, :data
 
       def initialize(attributes)
         @type = attributes[:type] || raise(ArgumentError.new(":type is required"))
         @data = attributes[:data] || raise(ArgumentError.new(":data is required"))
-      end
-
-      def keyspace
-        :custom
       end
 
       def as_json(_options = {})

--- a/lib/timber/contexts/http.rb
+++ b/lib/timber/contexts/http.rb
@@ -7,6 +7,8 @@ module Timber
     # @note This context should be installed automatically through probes,
     #   such as the {Probes::RackHTTPContext} probe.
     class HTTP < Context
+      @keyspace = :http
+
       attr_reader :method, :path, :remote_addr, :request_id
 
       def initialize(attributes)
@@ -14,10 +16,6 @@ module Timber
         @path = attributes[:path] || raise(ArgumentError.new(":path is required"))
         @remote_addr = attributes[:remote_addr]
         @request_id = attributes[:request_id]
-      end
-
-      def keyspace
-        :http
       end
 
       def as_json(_options = {})

--- a/lib/timber/contexts/organization.rb
+++ b/lib/timber/contexts/organization.rb
@@ -16,15 +16,13 @@ module Timber
     #   end
     #
     class Organization < Context
+      @keyspace = :organization
+
       attr_reader :id, :name
 
       def initialize(attributes)
         @id = attributes[:id]
         @name = attributes[:name]
-      end
-
-      def keyspace
-        :organization
       end
 
       def as_json(_options = {})

--- a/lib/timber/contexts/tags.rb
+++ b/lib/timber/contexts/tags.rb
@@ -1,0 +1,22 @@
+module Timber
+  module Contexts
+    # Adds unnamed tags to the context.
+    #
+    # **Warning:** It is highly recommend that you use custom contexts instead. As they are
+    # more descriptive. This module exists primarily to support the ActiveSupport::TaggedLogging
+    # antipattern.
+    class Tags < Context
+      @keyspace = :tags
+
+      attr_reader :values
+
+      def initialize(attributes)
+        @values = attributes[:values] || raise(ArgumentError.new(":values is required"))
+      end
+
+      def as_json(_options = {})
+        values
+      end
+    end
+  end
+end

--- a/lib/timber/contexts/user.rb
+++ b/lib/timber/contexts/user.rb
@@ -17,15 +17,13 @@ module Timber
     #   end
     #
     class User < Context
+      @keyspace = :user
+
       attr_reader :id, :name
 
       def initialize(attributes)
         @id = attributes[:id]
         @name = attributes[:name]
-      end
-
-      def keyspace
-        :user
       end
 
       def as_json(_options = {})

--- a/lib/timber/current_context.rb
+++ b/lib/timber/current_context.rb
@@ -4,40 +4,101 @@ module Timber
   # Holds the current context in a thread safe memory storage. This context is
   # appended to every log line. Think of context as join data between your log lines,
   # allowing you to relate them and filter them appropriately.
+  #
+  # @note Because context is appended to every log line, it is recommended that you limit this
+  #   to only neccessary data needed to relate your log lines.
   class CurrentContext
     include Singleton
 
     THREAD_NAMESPACE = :_timber_current_context.freeze
 
     class << self
-      # Convenience method for {#with}.
-      #
-      # @example Adding a context
-      #   custom_context = Timber::Contexts::Custom.new(type: :keyspace, data: %{my: "data"})
-      #   Timber::CurrentContext.with(custom_context) do
-      #     # ... anything logged here will have the context ...
-      #   end
+      # Convenience method for {#with}. See {#with} for full details and examples.
       def with(*args, &block)
         instance.with(*args, &block)
       end
+
+      # Convenience method for {#add}. See {#add} for full details and examples.
+      def add(*args)
+        instance.add(*args)
+      end
+
+      # Convenience method for {#remove}. See {#remove} for full details and examples.
+      def remove(*args)
+        instance.remove(*args)
+      end
+
+      def hash(*args)
+        instance.hash(*args)
+      end
     end
 
-    # Adds a context to the current stack.
-    def with(data)
-      key = data.keyspace
-      hash[key] = data
+    # Adds a context and then removes it when the block is finished executing.
+    #
+    # @note Because context is included with every log line, it is recommended that you limit this
+    #   to only neccessary data.
+    #
+    # @example Adding a custom context
+    #   custom_context = Timber::Contexts::Custom.new(type: :organization, data: %{id: 1, name: "Timber"})
+    #   Timber::CurrentContext.with(custom_context) do
+    #     # ... anything logged here will include the context ...
+    #   end
+    #   # Be sure to checkout Timber::Contexts! These are officially supported and many of these
+    #   # will be automatically included via Timber::Probes
+    #
+    # @example Adding multiple contexts
+    #   Timber::CurrentContext.with(context1, context2) { ... }
+    def with(*contexts)
+      add(*contexts)
       yield
     ensure
-      hash.delete(key)
+      contexts.each do |context|
+        if context.keyspace == :custom
+          # Custom contexts are merged and should be removed the same
+          hash[context.keyspace].delete(context.type)
+        else
+          remove(context)
+        end
+      end
     end
 
+    # Adds contexts but does not remove them. See {#with} for automatic maintenance and {#remove}
+    # to remove them yourself.
+    #
+    # @note Because context is included with every log line, it is recommended that you limit this
+    #   to only neccessary data.
+    def add(*contexts)
+      contexts.each do |context|
+        key = context.keyspace
+        json = context.as_json # Convert to json now so that we aren't doing it for every line
+        if key == :custom
+          # Custom contexts are merged into the space
+          hash[key] ||= {}
+          hash[key].merge(json)
+        else
+          hash[key] = json
+        end
+      end
+    end
+
+    # Removes a context. This must be a {Timber::Context} type. See {Timber::Contexts} for a list.
+    # If you wish to remove by key, or some other way, use {#hash} and modify the hash accordingly.
+    def remove(*contexts)
+      contexts.each do |context|
+        hash.delete(context.keyspace)
+      end
+    end
+
+    # The internal hash that is maintained. It is recommended that you use {#with} and {#add}
+    # for hash maintenance.
+    def hash
+      Thread.current[THREAD_NAMESPACE] ||= {}
+    end
+
+    # Snapshots the current context so that you get a moment in time representation of the context,
+    # since the context can change as execution proceeds.
     def snapshot
       hash.clone
     end
-
-    private
-      def hash
-        Thread.current[THREAD_NAMESPACE] ||= {}
-      end
   end
 end

--- a/lib/timber/probes.rb
+++ b/lib/timber/probes.rb
@@ -2,6 +2,7 @@ require "timber/probes/action_controller_log_subscriber"
 require "timber/probes/action_dispatch_debug_exceptions"
 require "timber/probes/action_view_log_subscriber"
 require "timber/probes/active_record_log_subscriber"
+require "timber/probes/active_support_tagged_logging"
 require "timber/probes/rack_http_context"
 require "timber/probes/rails_rack_logger"
 
@@ -14,6 +15,7 @@ module Timber
       ActionDispatchDebugExceptions.insert!
       ActionViewLogSubscriber.insert!
       ActiveRecordLogSubscriber.insert!
+      ActiveSupportTaggedLogging.insert!
       RackHTTPContext.insert!(middleware, insert_before)
       RailsRackLogger.insert!
     end

--- a/lib/timber/probes/active_support_tagged_logging.rb
+++ b/lib/timber/probes/active_support_tagged_logging.rb
@@ -1,0 +1,58 @@
+module Timber
+  module Probes
+    # Reponsible for automatimcally tracking SQL query events in `ActiveRecord`, while still
+    # preserving the default log style.
+    class ActiveSupportTaggedLogging < Probe
+      module InstanceMethods
+        def self.included(mod)
+          mod.module_eval do
+            alias_method :_timber_original_push_tags, :push_tags
+            alias_method :_timber_original_pop_tags, :pop_tags
+
+            def call(severity, timestamp, progname, msg)
+              if is_a?(Timber::Logger::Formatter)
+                # Don't convert the message into a string
+                super(severity, timestamp, progname, msg)
+              else
+                super(severity, timestamp, progname, "#{tags_text}#{msg}")
+              end
+            end
+
+            def push_tags(*tags)
+              _timber_original_push_tags(*tags).tap do
+                if current_tags.size > 0
+                  context = Contexts::Tags.new(values: current_tags)
+                  CurrentContext.add(context)
+                end
+              end
+            end
+
+            def pop_tags(size = 1)
+              _timber_original_pop_tags(size).tap do
+                if current_tags.size == 0
+                  CurrentContext.remove(Contexts::Tags)
+                else
+                  context = Contexts::Tags.new(values: current_tags)
+                  CurrentContext.add(context)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def initialize
+        require "active_support/tagged_logging"
+      rescue LoadError => e
+        raise RequirementNotMetError.new(e.message)
+      end
+
+      def insert!
+        return true if ActiveSupport::TaggedLogging.include?(InstanceMethods)
+        if defined?(ActiveSupport::TaggedLogging::Formatter)
+          ActiveSupport::TaggedLogging::Formatter.send(:include, InstanceMethods)
+        end
+      end
+    end
+  end
+end

--- a/lib/timber/probes/rack_http_context.rb
+++ b/lib/timber/probes/rack_http_context.rb
@@ -15,7 +15,7 @@ module Timber
             remote_addr: request.ip,
             request_id: request_id(env)
           )
-          CurrentContext.instance.with(context) do
+          CurrentContext.with(context) do
             @app.call(env)
           end
         end

--- a/lib/timberio.rb
+++ b/lib/timberio.rb
@@ -1,1 +1,0 @@
-require "timber"

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -29,7 +29,7 @@ describe Timber::Logger, :rails_23 => true do
         end
 
         around(:each) do |example|
-          Timber::CurrentContext.instance.with(http_context) do
+          Timber::CurrentContext.with(http_context) do
             example.run
           end
         end
@@ -81,8 +81,10 @@ describe Timber::Logger, :rails_23 => true do
 
       it "should format properly with events" do
         message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
-        logger.info(message)
-        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}}\n")
+        logger.tagged("tag") do
+          logger.info(message)
+        end
+        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}},\"context\":{\"tags\":[\"tag\"]}}\n")
       end
     end
   end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -76,7 +76,7 @@ describe Timber::Logger, :rails_23 => true do
       end
     end
 
-    context "with TaggedLogging" do
+    context "with TaggedLogging", :rails_23 => false do
       let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
 
       it "should format properly with events" do

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -76,15 +76,17 @@ describe Timber::Logger, :rails_23 => true do
       end
     end
 
-    context "with TaggedLogging", :rails_23 => false do
-      let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
+    if defined?(ActiveSupport::TaggedLogging)
+      context "with TaggedLogging", :rails_23 => false do
+        let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
 
-      it "should format properly with events" do
-        message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
-        logger.tagged("tag") do
-          logger.info(message)
+        it "should format properly with events" do
+          message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
+          logger.tagged("tag") do
+            logger.info(message)
+          end
+          expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}},\"context\":{\"tags\":[\"tag\"]}}\n")
         end
-        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}},\"context\":{\"tags\":[\"tag\"]}}\n")
       end
     end
 

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -75,15 +75,5 @@ describe Timber::Logger, :rails_23 => true do
         expect(io.string).to eq("{\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"message\":\"this is a test\"}\n")
       end
     end
-
-    context "with TaggedLogging" do
-      let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
-
-      it "should format properly with events" do
-        message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
-        logger.info(message)
-        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}}\n")
-      end
-    end
   end
 end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -75,5 +75,15 @@ describe Timber::Logger, :rails_23 => true do
         expect(io.string).to eq("{\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"message\":\"this is a test\"}\n")
       end
     end
+
+    context "with TaggedLogging" do
+      let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
+
+      it "should format properly with events" do
+        message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
+        logger.info(message)
+        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}}\n")
+      end
+    end
   end
 end

--- a/spec/timber/probes/rack_http_context_spec.rb
+++ b/spec/timber/probes/rack_http_context_spec.rb
@@ -41,11 +41,7 @@ describe Timber::Probes::RackHTTPContext do
         dispatch_rails_request("/rack_http")
         http_context = Thread.current[:_timber_context][:http]
 
-        expect(http_context).to be_kind_of(Timber::Contexts::HTTP)
-        expect(http_context.method).to eq("GET")
-        expect(http_context.path).to eq("/rack_http")
-        expect(http_context.remote_addr).to eq("123.456.789.10")
-        expect(http_context.request_id).to_not be_nil
+        expect(http_context).to eq({:method=>"GET", :path=>"/rack_http", :remote_addr=>"123.456.789.10", :request_id=>"unique-request-id-1234"})
         message = "Processing by RackHttpController#index as HTML @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"controller_call\":{\"controller\":\"RackHttpController\",\"action\":\"index\"}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\nCompleted 200 OK in 0.0ms (Views: 1.0ms) @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"http_response\":{\"status\":200,\"time_ms\":0.0}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\n"
         expect(io.string).to eq(message)
       end

--- a/timber.gemspec
+++ b/timber.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 require "timber/version"
 
 Gem::Specification.new do |s|
-  s.name        = "timberio"
+  s.name        = "timber"
   s.version     = Timber::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Timber Technologies, Inc."]


### PR DESCRIPTION
No idea why rails would decide to pollute the logger with all of this, but here we go! This also requires us to add the `context.tags` keyspace which is silly when we have custom contexts. Hence the warnings in the docs.