### PR TITLE
Implement System context

### DIFF
--- a/lib/timber/context.rb
+++ b/lib/timber/context.rb
@@ -17,7 +17,7 @@ module Timber
     end
 
     def to_json(options = {})
-      Util::Hash.compact(as_json).to_json(options)
+      as_json.to_json(options)
     end
 
     def to_msgpack(*args)

--- a/lib/timber/contexts.rb
+++ b/lib/timber/contexts.rb
@@ -1,8 +1,8 @@
 require "timber/contexts/custom"
 require "timber/contexts/http"
 require "timber/contexts/organization"
-require "timber/contexts/os_process"
 require "timber/contexts/runtime"
+require "timber/contexts/system"
 require "timber/contexts/tags"
 require "timber/contexts/user"
 

--- a/lib/timber/contexts/system.rb
+++ b/lib/timber/contexts/system.rb
@@ -1,8 +1,8 @@
 module Timber
   module Contexts
     # Tracks OS level process information, such as the process ID.
-    class OSProcess < Context
-      @keyspace = :os_process
+    class System < Context
+      @keyspace = :system
 
       attr_reader :pid
 

--- a/lib/timber/event.rb
+++ b/lib/timber/event.rb
@@ -11,7 +11,7 @@ module Timber
     end
 
     def to_json(options = {})
-      Util::Hash.compact(as_json).to_json(options)
+      as_json.to_json(options)
     end
 
     def to_msgpack(*args)

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -21,6 +21,11 @@ module Timber
       @time = time.utc
       @progname = progname
       @message = message
+
+      context_snapshot = {} if context_snapshot.nil?
+      system_context = Contexts::System.new(pid: Process.pid)
+      context_snapshot[system_context.keyspace] = system_context.as_json
+
       @context_snapshot = context_snapshot
       @event = event
     end
@@ -51,7 +56,7 @@ module Timber
     end
 
     def to_json(options = {})
-      as_json(options).to_json
+      Util::Hash.compact(as_json(options)).to_json
     end
 
     def to_msgpack(*args)

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -66,7 +66,7 @@ describe Timber::LogDevices::HTTP do
       request_queue = http.instance_variable_get(:@request_queue)
       request = request_queue.deq
       expect(request).to be_kind_of(Net::HTTP::Post)
-      expect(request.body).to eq("\x92\x83\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1\x83\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 2".force_encoding("ASCII-8BIT"))
+      expect(request.body).to start_with("\x92\x84\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1".force_encoding("ASCII-8BIT"))
 
       message_queue = http.instance_variable_get(:@msg_queue)
       expect(message_queue.size).to eq(0)
@@ -98,7 +98,7 @@ describe Timber::LogDevices::HTTP do
     it "should start a intervaled flush thread and flush on an interval" do
       stub = stub_request(:post, "https://logs.timber.io/frames").
         with(
-          :body => "\x92\x83\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1\x83\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 2".force_encoding("ASCII-8BIT"),
+          :body => start_with("\x92\x84\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1".force_encoding("ASCII-8BIT")),
           :headers => {
             'Accept' => 'application/json',
             'Authorization' => 'Basic TVlLRVk=',

--- a/spec/timber/log_entry_spec.rb
+++ b/spec/timber/log_entry_spec.rb
@@ -9,7 +9,7 @@ describe Timber::LogEntry, :rails_23 => true do
       context = {custom: Timber::Contexts::Custom.new(type: :context_type, data: {b: 1})}
       log_entry = described_class.new("INFO", time, nil, "log message", context, event)
       msgpack = log_entry.to_msgpack
-      expect(msgpack).to eq("\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xABlog message\xA5event\x81\xAFserver_side_app\x81\xA6custom\x81\xAAevent_type\x81\xA1a\x01\xA7context\x81\xA6custom\x81\xACcontext_type\x81\xA1b\x01".force_encoding("ASCII-8BIT"))
+      expect(msgpack).to start_with("\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xABlog message".force_encoding("ASCII-8BIT"))
     end
   end
 end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -15,7 +15,7 @@ describe Timber::Logger, :rails_23 => true do
 
       it "should accept strings" do
         logger.info("this is a test")
-        expect(io.string).to eq("this is a test @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"}\n")
+        expect(io.string).to start_with("this is a test @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"")
       end
 
       context "with a context" do
@@ -37,7 +37,8 @@ describe Timber::Logger, :rails_23 => true do
         it "should snapshot and include the context" do
           expect(Timber::CurrentContext.instance).to receive(:snapshot).and_call_original
           logger.info("this is a test")
-          expect(io.string).to eq("this is a test @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"context\":{\"http\":{\"method\":\"POST\",\"path\":\"/checkout\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"abcd1234\"}}}\n")
+          expect(io.string).to start_with("this is a test @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"")
+          expect(io.string).to include("\"http\":{\"method\":\"POST\",\"path\":\"/checkout\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"abcd1234\"}")
         end
       end
 
@@ -45,25 +46,28 @@ describe Timber::Logger, :rails_23 => true do
         message = {message: "payment rejected", type: :payment_rejected, data: {customer_id: "abcde1234", amount: 100}}
         expect(Timber::Events).to receive(:build).with(message).and_call_original
         logger.info(message)
-        expect(io.string).to eq("payment rejected @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"custom\":{\"payment_rejected\":{\"customer_id\":\"abcde1234\",\"amount\":100}}}}}\n")
+        expect(io.string).to start_with("payment rejected @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",")
+        expect(io.string).to include("\"event\":{\"server_side_app\":{\"custom\":{\"payment_rejected\":{\"customer_id\":\"abcde1234\",\"amount\":100}}}}")
       end
 
       it "should log properly when an event is passed" do
         message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
         logger.info(message)
-        expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}}}\n")
+        expect(io.string).to start_with("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",")
+        expect(io.string).to include("\"event\":{\"server_side_app\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}}")
       end
 
       it "should allow functions" do
         logger.info do
           {message: "payment rejected", type: :payment_rejected, data: {customer_id: "abcde1234", amount: 100}}
         end
-        expect(io.string).to eq("payment rejected @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"custom\":{\"payment_rejected\":{\"customer_id\":\"abcde1234\",\"amount\":100}}}}}\n")
+        expect(io.string).to start_with("payment rejected @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",")
+        expect(io.string).to include("\"event\":{\"server_side_app\":{\"custom\":{\"payment_rejected\":{\"customer_id\":\"abcde1234\",\"amount\":100}}}}")
       end
 
       it "should escape new lines" do
         logger.info "first\nsecond"
-        expect(io.string).to eq("first\\nsecond @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"}\n")
+        expect(io.string).to start_with("first\\nsecond @timber.io")
       end
     end
 
@@ -72,7 +76,7 @@ describe Timber::Logger, :rails_23 => true do
 
       it "should log in the correct format" do
         logger.info("this is a test")
-        expect(io.string).to eq("{\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"message\":\"this is a test\"}\n")
+        expect(io.string).to start_with("{\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"message\":\"this is a test\"")
       end
     end
 
@@ -85,7 +89,7 @@ describe Timber::Logger, :rails_23 => true do
           logger.tagged("tag") do
             logger.info(message)
           end
-          expect(io.string).to eq("select * from users @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56}}},\"context\":{\"tags\":[\"tag\"]}}\n")
+          expect(io.string).to include("\"context\":{\"tags\":[\"tag\"]")
         end
       end
     end

--- a/spec/timber/probes/action_controller_log_subscriber_spec.rb
+++ b/spec/timber/probes/action_controller_log_subscriber_spec.rb
@@ -55,13 +55,12 @@ describe Timber::Probes::ActionControllerLogSubscriber do
             # Rails uses this to calculate the view runtime below
             allow(Benchmark).to receive(:ms).and_return(1).and_yield
             dispatch_rails_request("/log_subscriber")
-            message1 = <<-MSG
-              Processing by LogSubscriberController#index as HTML @timber.io {"level":"info","dt":"2016-09-01T12:00:00.000000Z","event":{"server_side_app":{"controller_call":{"controller":"LogSubscriberController","action":"index"}}},"context":{"http":{"method":"GET","path":"/log_subscriber","remote_addr":"123.456.789.10","request_id":"unique-request-id-1234"}}}
-            MSG
-            message2 = <<-MSG
-              Completed 200 OK in 0.0ms (Views: 1.0ms) @timber.io {"level":"info","dt":"2016-09-01T12:00:00.000000Z","event":{"server_side_app":{"http_response":{"status":200,"time_ms":0.0}}},"context":{"http":{"method":"GET","path":"/log_subscriber","remote_addr":"123.456.789.10","request_id":"unique-request-id-1234"}}}
-            MSG
-            expect(io.string).to eq(message1.strip + "\n" + message2.strip + "\n")
+            lines = io.string.split("\n")
+            expect(lines.length).to eq(2)
+            expect(lines[0]).to start_with('Processing by LogSubscriberController#index as HTML @timber.io {"level":"info","dt":"2016-09-01T12:00:00.000000Z"')
+            expect(lines[0]).to include('"event":{"server_side_app":{"controller_call":{"controller":"LogSubscriberController","action":"index"}}}')
+            expect(lines[1]).to start_with('Completed 200 OK in 0.0ms (Views: 1.0ms) @timber.io {"level":"info","dt":"2016-09-01T12:00:00.000000Z"')
+            expect(lines[1]).to include('"event":{"server_side_app":{"http_response":{"status":200,"time_ms":0.0}}}')
           end
         end
       end

--- a/spec/timber/probes/action_view_log_subscriber_spec.rb
+++ b/spec/timber/probes/action_view_log_subscriber_spec.rb
@@ -51,8 +51,8 @@ describe Timber::Probes::ActionViewLogSubscriber do
           it "should log the controller call event" do
             allow_any_instance_of(Timber::Probes::ActionViewLogSubscriber::LogSubscriber).to receive(:logger).and_return(logger)
             dispatch_rails_request("/action_view_log_subscriber")
-            message = "  Rendered spec/support/rails/templates/template.html (0.0ms) @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"template_render\":{\"name\":\"spec/support/rails/templates/template.html\",\"time_ms\":0.0}}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/action_view_log_subscriber\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\n"
-            expect(io.string).to eq(message)
+            expect(io.string).to start_with("  Rendered spec/support/rails/templates/template.html (0.0ms) @timber.io {\"level\":\"info\"")
+            expect(io.string).to include("\"event\":{\"server_side_app\":{\"template_render\":{\"name\":\"spec/support/rails/templates/template.html\",\"time_ms\":0.0}}},")
           end
         end
       end

--- a/spec/timber/probes/rails_rack_logger_spec.rb
+++ b/spec/timber/probes/rails_rack_logger_spec.rb
@@ -33,13 +33,13 @@ describe Timber::Probes::RailsRackLogger do
     end
 
     describe "#started_request_message" do
-      it "should set the context" do
+      it "should add the request event" do
         allow(::Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production")) # Rails 3.2.X
         allow(::Rails).to receive(:logger).and_return(logger) # Rails 3.2.X
         allow_any_instance_of(::Rails::Rack::Logger).to receive(:logger).and_return(logger)
         dispatch_rails_request("/rails_rack_logger")
-        message = "Started GET \"/rails_rack_logger\" for 123.456.789.10 @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"http_request\":{\"host\":\"example.org\",\"method\":\"GET\",\"path\":\"/rails_rack_logger\",\"port\":80,\"headers\":{\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/rails_rack_logger\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\n"
-        expect(io.string).to eq(message)
+        expect(io.string).to start_with("Started GET \"/rails_rack_logger\" for 123.456.789.10 @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"")
+        expect(io.string).to include("\"event\":{\"server_side_app\":{\"http_request\":{\"host\":\"example.org\",\"method\":\"GET\",\"path\":\"/rails_rack_logger\",\"port\":80,\"headers\":{\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}")
       end
     end
   end

--- a/spec/timber/rack_middlewares/http_context_spec.rb
+++ b/spec/timber/rack_middlewares/http_context_spec.rb
@@ -41,8 +41,7 @@ describe Timber::RackMiddlewares::HTTPContext do
       http_context = Thread.current[:_timber_context][:http]
 
       expect(http_context).to eq({:method=>"GET", :path=>"/rack_http", :remote_addr=>"123.456.789.10", :request_id=>"unique-request-id-1234"})
-      message = "Processing by RackHttpController#index as HTML @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"controller_call\":{\"controller\":\"RackHttpController\",\"action\":\"index\"}}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\nCompleted 200 OK in 0.0ms (Views: 1.0ms) @timber.io {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",\"event\":{\"server_side_app\":{\"http_response\":{\"status\":200,\"time_ms\":0.0}}},\"context\":{\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}}}\n"
-      expect(io.string).to eq(message)
+      expect(io.string).to include("\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}")
     end
   end
 end


### PR DESCRIPTION
As pointed out by @DavidAntaramian via http://man7.org/linux/man-pages/man2/getpid.2.html:

      Since glibc version 2.3.4, the glibc wrapper function for getpid()
      caches PIDs, so as to avoid additional system calls when a process
      calls getpid() repeatedly.  Normally this caching is invisible, but
      its correct operation relies on support in the wrapper functions for
      fork(2), vfork(2), and clone(2): if an application bypasses the glibc
      wrappers for these system calls by using syscall(2), then a call to
      getpid() in the child will return the wrong value (to be precise: it
      will return the PID of the parent process).  See also clone(2) for
      discussion of a case where getpid() may return the wrong value even
      when invoking clone(2) via the glibc wrapper function.

This should not affect performance.