### PR TITLE
Specify the log event schema

### DIFF
--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -3,6 +3,7 @@ module Timber
   # `Logger` and the log device that you set it up with.
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.2/schema.json".freeze
 
     attr_reader :level, :time, :progname, :message, :context_snapshot, :event
 
@@ -32,7 +33,7 @@ module Timber
 
     def as_json(options = {})
       options ||= {}
-      hash = {level: level, dt: formatted_dt, message: message}
+      hash = {:level => level, :dt => formatted_dt, :message => message}
 
       if !event.nil?
         hash[:event] = event
@@ -41,6 +42,8 @@ module Timber
       if !context_snapshot.nil? && context_snapshot.length > 0
         hash[:context] = context_snapshot
       end
+
+      hash[:"$schema"] = SCHEMA
 
       if options[:only]
         hash.select do |key, _value|

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -66,7 +66,7 @@ describe Timber::LogDevices::HTTP do
       request_queue = http.instance_variable_get(:@request_queue)
       request = request_queue.deq
       expect(request).to be_kind_of(Net::HTTP::Post)
-      expect(request.body).to start_with("\x92\x84\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1".force_encoding("ASCII-8BIT"))
+      expect(request.body).to start_with("\x92\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1\xA7context\x81".force_encoding("ASCII-8BIT"))
 
       message_queue = http.instance_variable_get(:@msg_queue)
       expect(message_queue.size).to eq(0)
@@ -98,7 +98,7 @@ describe Timber::LogDevices::HTTP do
     it "should start a intervaled flush thread and flush on an interval" do
       stub = stub_request(:post, "https://logs.timber.io/frames").
         with(
-          :body => start_with("\x92\x84\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1".force_encoding("ASCII-8BIT")),
+          :body => start_with("\x92\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xB2test log message 1\xA7context\x81\xA6system".force_encoding("ASCII-8BIT")),
           :headers => {
             'Accept' => 'application/json',
             'Authorization' => 'Basic TVlLRVk=',

--- a/spec/timber/log_entry_spec.rb
+++ b/spec/timber/log_entry_spec.rb
@@ -9,7 +9,7 @@ describe Timber::LogEntry, :rails_23 => true do
       context = {custom: Timber::Contexts::Custom.new(type: :context_type, data: {b: 1})}
       log_entry = described_class.new("INFO", time, nil, "log message", context, event)
       msgpack = log_entry.to_msgpack
-      expect(msgpack).to start_with("\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xABlog message".force_encoding("ASCII-8BIT"))
+      expect(msgpack).to start_with("\x86\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA7message\xABlog message\xA5event".force_encoding("ASCII-8BIT"))
     end
   end
 end


### PR DESCRIPTION
Adds `$schema` to the payload so that we can support versions properly.