### PR TITLE
Capture all HTTP headers and bodies

### DIFF
--- a/lib/timber/events.rb
+++ b/lib/timber/events.rb
@@ -1,6 +1,8 @@
 require "timber/events/controller_call"
 require "timber/events/custom"
 require "timber/events/exception"
+require "timber/events/http_client_request"
+require "timber/events/http_client_response"
 require "timber/events/http_server_request"
 require "timber/events/http_server_response"
 require "timber/events/sql_query"

--- a/lib/timber/probes/action_controller_log_subscriber/log_subscriber.rb
+++ b/lib/timber/probes/action_controller_log_subscriber/log_subscriber.rb
@@ -33,8 +33,6 @@ module Timber
               status = extract_status(exception_class_name)
             end
 
-            raise payload.inspect
-
             Events::HTTPServerResponse.new(
               status: status,
               time_ms: event.duration,

--- a/lib/timber/probes/action_controller_log_subscriber/log_subscriber.rb
+++ b/lib/timber/probes/action_controller_log_subscriber/log_subscriber.rb
@@ -33,6 +33,8 @@ module Timber
               status = extract_status(exception_class_name)
             end
 
+            raise payload.inspect
+
             Events::HTTPServerResponse.new(
               status: status,
               time_ms: event.duration,

--- a/lib/timber/util/http_event.rb
+++ b/lib/timber/util/http_event.rb
@@ -1,0 +1,25 @@
+module Timber
+  module Util
+    module HTTPEvent
+      def self.full_path(path, query_string)
+        if query_string
+          "#{path}?#{query_string}"
+        else
+          path
+        end
+      end
+
+      def self.normalize_body(body)
+        if body.is_a?(String) && body.length > 2000
+          body.truncate(2000)
+        else
+          body
+        end
+      end
+
+      def normalize_headers(headers)
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
Captures all HTTP event headers as well as the bodies (truncated at 2000 characters).