### PR TITLE
Remove event namespace

### DIFF
--- a/lib/timber/events/controller_call.rb
+++ b/lib/timber/events/controller_call.rb
@@ -24,7 +24,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:controller_call => to_hash}}
+        {:controller_call => to_hash}
       end
 
       def message

--- a/lib/timber/events/exception.rb
+++ b/lib/timber/events/exception.rb
@@ -26,7 +26,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:exception => to_hash}}
+        {:exception => to_hash}
       end
 
       def message

--- a/lib/timber/events/http_client_request.rb
+++ b/lib/timber/events/http_client_request.rb
@@ -31,7 +31,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:http_client_request => to_hash}}
+        {:http_client_request => to_hash}
       end
 
       def message

--- a/lib/timber/events/http_client_response.rb
+++ b/lib/timber/events/http_client_response.rb
@@ -26,7 +26,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:http_client_response => to_hash}}
+        {:http_client_response => to_hash}
       end
 
       def message

--- a/lib/timber/events/http_server_request.rb
+++ b/lib/timber/events/http_server_request.rb
@@ -27,7 +27,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:http_server_request => to_hash}}
+        {:http_server_request => to_hash}
       end
 
       def message

--- a/lib/timber/events/http_server_response.rb
+++ b/lib/timber/events/http_server_response.rb
@@ -22,7 +22,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:http_server_response => to_hash}}
+        {:http_server_response => to_hash}
       end
 
       def message

--- a/lib/timber/events/sql_query.rb
+++ b/lib/timber/events/sql_query.rb
@@ -20,7 +20,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:sql_query => to_hash}}
+        {:sql_query => to_hash}
       end
     end
   end

--- a/lib/timber/events/template_render.rb
+++ b/lib/timber/events/template_render.rb
@@ -20,7 +20,7 @@ module Timber
       alias to_h to_hash
 
       def as_json(_options = {})
-        {:server_side_app => {:template_render => to_hash}}
+        {:template_render => to_hash}
       end
     end
   end

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -3,7 +3,7 @@ module Timber
   # `Logger` and the log device that you set it up with.
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/1.2.21/schema.json".freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/2.0.0/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -5,7 +5,7 @@ module Timber
   # `Logger` and the log device that you set it up with.
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/2.0.0/schema.json".freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/2.0.1/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 

--- a/lib/timber/version.rb
+++ b/lib/timber/version.rb
@@ -1,3 +1,3 @@
 module Timber
-  VERSION = "2.0.8"
+  VERSION = "2.0.9"
 end

--- a/spec/timber/integrations/action_controller/log_subscriber_spec.rb
+++ b/spec/timber/integrations/action_controller/log_subscriber_spec.rb
@@ -43,7 +43,7 @@ if defined?(::ActionController)
         lines = clean_lines(io.string.split("\n"))
         expect(lines.length).to eq(3)
         expect(lines[1]).to start_with('Processing by LogSubscriberController#index as HTML\n  Parameters: {"query"=>"value"} @metadata {"level":"info","dt":"2016-09-01T12:00:00.000000Z"')
-        expect(lines[1]).to include('"event":{"server_side_app":{"controller_call":{"controller":"LogSubscriberController","action":"index","params_json":"{\"query\":\"value\"}"}}}')
+        expect(lines[1]).to include('"event":{"controller_call":{"controller":"LogSubscriberController","action":"index","params_json":"{\"query\":\"value\"}"}}')
       end
 
       # Remove blank lines since Rails does this to space out requests in the logs

--- a/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
@@ -41,7 +41,7 @@ if defined?(::ActionDispatch)
         lines = clean_lines(io.string.split("\n"))
         expect(lines.length).to eq(3)
         expect(lines[2]).to start_with('RuntimeError (boom) @metadata {"level":"fatal",')
-        expect(lines[2]).to include("\"event\":{\"server_side_app\":{\"exception\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace\":[")
+        expect(lines[2]).to include("\"event\":{\"exception\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace\":[")
       end
 
       # Remove blank lines since Rails does this to space out requests in the logs

--- a/spec/timber/integrations/action_view/log_subscriber_spec.rb
+++ b/spec/timber/integrations/action_view/log_subscriber_spec.rb
@@ -53,7 +53,7 @@ if defined?(::ActionView)
             dispatch_rails_request("/action_view_log_subscriber")
             lines = clean_lines(io.string.split("\n"))
             expect(lines[2].strip).to start_with("Rendered spec/support/rails/templates/template.html (0.0ms) @metadata {\"level\":\"info\"")
-            expect(lines[2]).to include("\"event\":{\"server_side_app\":{\"template_render\":{\"name\":\"spec/support/rails/templates/template.html\",\"time_ms\":0.0}}},")
+            expect(lines[2]).to include("\"event\":{\"template_render\":{\"name\":\"spec/support/rails/templates/template.html\",\"time_ms\":0.0}},")
           end
         end
       end

--- a/spec/timber/integrations/active_record/log_subscriber_spec.rb
+++ b/spec/timber/integrations/active_record/log_subscriber_spec.rb
@@ -38,7 +38,7 @@ if defined?(::ActiveRecord)
           expect(string).to include("select * from users")
           expect(string).to include("@metadata")
           expect(string).to include("\"level\":\"debug\"")
-          expect(string).to include("\"event\":{\"server_side_app\":{\"sql_query\"")
+          expect(string).to include("\"event\":{\"sql_query\"")
         end
       end
     end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -54,7 +54,7 @@ describe Timber::Logger, :rails_23 => true do
         message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
         logger.info(message)
         expect(io.string).to start_with("select * from users @metadata {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\",")
-        expect(io.string).to include("\"event\":{\"server_side_app\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56.0}}}")
+        expect(io.string).to include("\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56.0}}")
       end
 
       it "should allow :time_ms" do


### PR DESCRIPTION
This PR removes the sub-level `event` namespace in the resulting event structure. This simplifies the JSON and decouples it from Timber.