### PR TITLE
Add spec for nil values when normalizing headers

### DIFF
--- a/spec/timber/util/http_event_spec.rb
+++ b/spec/timber/util/http_event_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Timber::Util::HTTPEvent, :rails_23 => true do
+  describe ".normalize_headers" do
+    it "should ignore nils" do
+      result = described_class.normalize_headers({"key" => nil})
+      expect(result).to eq({"key" => nil})
+    end
+  end
+end


### PR DESCRIPTION
The fix for this was pushed in a previous commit, but I wanted to get a test in place and officially close the issue:

Closes https://github.com/timberio/timber-ruby/issues/77