### PR TITLE
Make sure Timber is the absolute last middleware inserted

### DIFF
--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -18,7 +18,11 @@ module Timber
             attr_accessor :timber_operations
 
             alias old_merge_into merge_into
-            alias old_plus +
+
+            begin
+              alias old_plus +
+            rescue NameError
+            end
 
             def +(*args)
               result = old_plus(*args)

--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -3,6 +3,15 @@ module Timber
     # Module for Rails specific code, such as the Railtie and any methods that assist
     # with Rails setup.
     module Rails
+      # Because of the crazy way Rails sorts it's initializers, it is
+      # impossible for Timber to be inserted after Devise's omnitauth
+      # middlewares.
+      # See: https://github.com/plataformatec/devise/blob/master/lib/devise/rails.rb#L22
+      # As such, we take a brute force approach here, ensuring we are inserted last
+      # no matter what. This ensures that we come after authentication so that we can
+      # properly set the user context.
+      #
+      # @private
       module MiddlewareStackProxyFix
         def self.included(klass)
           klass.class_eval do
@@ -53,22 +62,6 @@ module Timber
           end
 
           config.app_middleware.timber_operations = timber_operations
-
-          # Because of the crazy way Rails sorts it's initializers, it is
-          # impossible for Timber to be inserted after Devise's omnitauth
-          # middlewares.
-          # See: https://github.com/plataformatec/devise/blob/master/lib/devise/rails.rb#L22
-          # As such, we take a brute force approach here, ensuring we are inserted last
-          # no matter what. This ensures that we come after authentication so that we can
-          # properly set the user context.
-          # config.app_middleware.instance_eval do
-          #   def merge_into(*args)
-          #     raise "WTF"
-          #     @operations -= @timber_operations
-          #     @operations += @timber_operations
-          #     super
-          #   end
-          # end
         end
       end
 

--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -31,7 +31,6 @@ module Timber
                 @operations -= timber_operations
                 @operations += timber_operations
               end
-              puts "\n\n" + timber_operations.inspect
               old_merge_into(*args)
             end
           end

--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -19,6 +19,7 @@ module Timber
 
             alias old_merge_into merge_into
 
+            # This method does not exist for older versions of rails
             begin
               alias old_plus +
             rescue NameError
@@ -54,12 +55,7 @@ module Timber
           Rails.set_logger(logger)
 
           Integrations.integrate!
-        end
 
-        # Ensures that we insert the middlewares last. We need to insert these last
-        # because initializers, such as Omniauth, insert middleware. If we are not
-        # after these initializers we will not capture user context, for example.
-        initializer(:timber_middlewares, after: :load_config_initializers, before: :build_middleware_stack) do
           timber_operations = Integrations::Rack.middlewares.collect do |middleware_class|
             [:use, [middleware_class], nil]
           end

--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -1,5 +1,3 @@
-require "devise/rails"
-
 module Timber
   module Frameworks
     # Module for Rails specific code, such as the Railtie and any methods that assist


### PR DESCRIPTION
This ensures Timber comes after all authentication middleware, ensuring that we capture user context.