### PR TITLE
Support logging non-string objects

### DIFF
--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -23,7 +23,11 @@ module Timber
       @level = level
       @time = time.utc
       @progname = progname
-      @message = message.is_a?(String) ? message : message.to_s
+
+      # If the message is not a string we call inspect to ensure it is a string.
+      # This follows the default behavior set by ::Logger
+      # See: https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L615
+      @message = message.is_a?(String) ? message : message.inspect
       @tags = options[:tags]
       @time_ms = options[:time_ms]
 

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -23,7 +23,7 @@ module Timber
       @level = level
       @time = time.utc
       @progname = progname
-      @message = message
+      @message = message.is_a?(String) ? message : message.to_s
       @tags = options[:tags]
       @time_ms = options[:time_ms]
 

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -18,6 +18,11 @@ describe Timber::Logger, :rails_23 => true do
         expect(io.string).to start_with("this is a test @metadata {\"level\":\"info\",\"dt\":\"2016-09-01T12:00:00.000000Z\"")
       end
 
+      it "should non-strings" do
+        logger.info(true)
+        expect(io.string).to start_with("true @metadata")
+      end
+
       context "with a context" do
         let(:http_context) do
           Timber::Contexts::HTTP.new(
@@ -169,6 +174,11 @@ describe Timber::Logger, :rails_23 => true do
       expect(io.string).to start_with("message @metadata")
       expect(io.string).to include('"level":"info"')
       expect(io.string).to include('"tags":["tag"]')
+    end
+
+    it "should accept non-string messages" do
+      logger.info(true)
+      expect(io.string).to start_with("true @metadata")
     end
   end
 


### PR DESCRIPTION
The default ruby `::Logger` calls `inspect` on any object logged, this does the same.