### PR TITLE
Allow Rails to set the logger

### DIFF
--- a/lib/timber/config.rb
+++ b/lib/timber/config.rb
@@ -133,7 +133,11 @@ module Timber
     # @example Everything else
     #   Timber::Config.instance.logger = Timber::Logger.new(STDOUT)
     def logger
-      @logger || Logger.new(STDOUT)
+      if @logger.is_a?(Proc)
+        @logger.call()
+      else
+        @logger ||= Logger.new(STDOUT)
+      end
     end
 
     private

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -46,7 +46,12 @@ if defined?(::Rails)
         #
         # You can see here that they use simple class attribute, hence the reason we need
         # to update all of them: https://github.com/rails/rails/blob/700ec897f97c60016ad748236bf3a49ef15a20de/actionview/lib/action_view/base.rb#L157
-        Timber::Frameworks::Rails.set_logger(logger)
+        ::ActionCable::Server::Base.logger = logger if defined?(::ActionCable::Server::Base) && ::ActionCable::Server::Base.respond_to?(:logger=)
+        ::ActionController::Base.logger = logger if defined?(::ActionController::Base) && ::ActionController::Base.respond_to?(:logger=)
+        ::ActionMailer::Base.logger = logger if defined?(::ActionMailer::Base) && ::ActionMailer::Base.respond_to?(:logger=)
+        ::ActionView::Base.logger = logger if defined?(::ActionView::Base) && ::ActionView::Base.respond_to?(:logger=)
+        ::ActiveRecord::Base.logger = logger if defined?(::ActiveRecord::Base) && ::ActiveRecord::Base.respond_to?(:logger=)
+        ::Rails.logger = logger
 
         yield
 


### PR DESCRIPTION
This removes setting the Rails logger explicitly in the `Railtie`. This code was legacy when we automatically installed timber and / or recommended an initializer. Because the Timber logger is now being set in the appropriate environment files we don't need to do any of this.