### PR TITLE
Handle request errors by starting a new connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 before_script:
 - echo $BUNDLE_GEMFILE
 - bundle install
-script: bundle exec rspec
+script: bundle exec rspec --format documentation
 matrix:
   fast_finish: true
   exclude:

--- a/lib/timber/config.rb
+++ b/lib/timber/config.rb
@@ -1,3 +1,4 @@
+require "logger"
 require "singleton"
 
 module Timber
@@ -12,6 +13,13 @@ module Timber
   #   config.append_metdata = false
   class Config
     class NoLoggerError < StandardError; end
+
+    class SimpleFormatter < ::Logger::Formatter
+      # This method is invoked when a log event occurs
+      def call(severity, timestamp, progname, msg)
+        "[Timber] #{String === msg ? msg : msg.inspect}\n"
+      end
+    end
 
     PRODUCTION_NAME = "production".freeze
     STAGING_NAME = "staging".freeze
@@ -54,6 +62,7 @@ module Timber
       file.binmode
       file.sync = config.autoflush_log
       file_logger = ::Logger.new(file)
+      file_logger.formatter = SimpleFormatter.new
       self.debug_logger = file_logger
     end
 
@@ -65,6 +74,7 @@ module Timber
     #   Timber::Config.instance.debug_to_file("log/timber.log")
     def debug_to_stdout
       stdout_logger = ::Logger.new(STDOUT)
+      stdout_logger.formatter = SimpleFormatter.new
       self.debug_logger = stdout_logger
     end
 

--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -48,8 +48,13 @@ module Timber
       class Railtie < ::Rails::Railtie
         config.timber = Config.instance
 
-        initializer(:timber, after: :initialize_logger) do
+        config.before_initialize do
           Timber::Config.instance.logger = Proc.new { ::Rails.logger }
+        end
+
+        # Must be loaded after initializers so that we respect any Timber configuration
+        # set
+        initializer(:timber, after: :load_config_initializers) do
           Integrations.integrate!
 
           timber_operations = Integrations::Rack.middlewares.collect do |middleware_class|

--- a/lib/timber/integrations/active_record/log_subscriber/timber_log_subscriber.rb
+++ b/lib/timber/integrations/active_record/log_subscriber/timber_log_subscriber.rb
@@ -1,6 +1,6 @@
-# We require all of ActiveRecord because #logger usses ActiveRecord::Base.
-# We can't require active_record/base directly because ActiveRecord does not require
-# files properly.
+# We require all of ActiveRecord because the #logger method in ::ActiveRecord::LogSubscriber
+# uses ActiveRecord::Base. We can't require active_record/base directly because ActiveRecord
+# does not require files properly and we receive unintialized constant errors.
 require "active_record"
 require "active_record/log_subscriber"
 

--- a/lib/timber/log_devices/http.rb
+++ b/lib/timber/log_devices/http.rb
@@ -209,7 +209,7 @@ module Timber
                 flush
               end
 
-              sleep(0.1)
+              sleep(0.5)
             rescue Exception => e
               logger.error("Intervaled HTTP flush failed: #{e.inspect}\n\n#{e.backtrace}")
             end

--- a/lib/timber/log_devices/http.rb
+++ b/lib/timber/log_devices/http.rb
@@ -118,6 +118,7 @@ module Timber
         @requests_per_conn = options[:requests_per_conn] || 2_500
         @msg_queue = LogMsgQueue.new(@batch_size)
         @request_queue = options[:request_queue] || SizedQueue.new(3)
+        @successive_error_count = 0
         @requests_in_flight = 0
       end
 
@@ -133,7 +134,7 @@ module Timber
         ensure_flush_threads_are_started
 
         if @msg_queue.full?
-          debug_logger.debug("Flushing timber buffer via write") if debug_logger
+          debug_logger.debug("Flushing HTTP buffer via write") if debug_logger
           flush
         end
         true
@@ -160,15 +161,15 @@ module Timber
         # Flush all remaining messages
         flush
 
-        # Kill the outlet thread gracefully. We do not want to kill it while a
-        # requst is inflight. Ideally we'd let it finish before we die.
-        if @outlet_thread
+        # Kill the request_outlet thread gracefully. We do not want to kill it while a
+        # request is inflight. Ideally we'd let it finish before we die.
+        if @request_outlet_thread
           4.times do
             if @requests_in_flight == 0 && @request_queue.size == 0
-              @outlet_thread.kill
+              @request_outlet_thread.kill
               break
             else
-              debug_logger.error("Timber is busy delivering the final log messages, " +
+              debug_logger.error("Busy delivering the final log messages, " +
                 "connection will close when complete.")
               sleep 1
             end
@@ -187,8 +188,8 @@ module Timber
         # threads are started after process forking.
         def ensure_flush_threads_are_started
           if @flush_continuously
-            if @outlet_thread.nil? || !@outlet_thread.alive?
-              @outlet_thread = Thread.new { outlet }
+            if @request_outlet_thread.nil? || !@request_outlet_thread.alive?
+              @request_outlet_thread = Thread.new { request_outlet }
             end
 
             if @flush_thread.nil? || !@flush_thread.alive?
@@ -200,15 +201,17 @@ module Timber
         def intervaled_flush
           # Wait specified time period before starting
           sleep @flush_interval
+
           loop do
             begin
               if intervaled_flush_ready?
-                debug_logger.debug("Flushing timber buffer via the interval") if debug_logger
+                debug_logger.debug("Flushing HTTP buffer via the interval") if debug_logger
                 flush
               end
+
               sleep(0.1)
             rescue Exception => e
-              logger.error("Timber intervaled flush failed: #{e.inspect}\n\n#{e.backtrace}")
+              logger.error("Intervaled HTTP flush failed: #{e.inspect}\n\n#{e.backtrace}")
             end
           end
         end
@@ -217,22 +220,30 @@ module Timber
           @last_flush.nil? || (Time.now.to_f - @last_flush.to_f).abs >= @flush_interval
         end
 
-        def outlet
+        def build_http
+          http = Net::HTTP.new(@timber_url.host, @timber_url.port)
+          http.set_debug_output(debug_logger) if debug_logger
+          http.use_ssl = true if @timber_url.scheme == 'https'
+          http.read_timeout = 30
+          http.ssl_timeout = 10
+          http.open_timeout = 10
+          http
+        end
+
+        def request_outlet
           loop do
-            http = Net::HTTP.new(@timber_url.host, @timber_url.port)
-            http.set_debug_output(debug_logger) if debug_logger
-            http.use_ssl = true if @timber_url.scheme == 'https'
-            http.read_timeout = 30
-            http.ssl_timeout = 10
-            http.open_timeout = 10
+            http = build_http
 
             begin
-              debug_logger.info("Starting Timber HTTP connection") if debug_logger
-              http.start(&:deliver_requests)
+              debug_logger.info("Starting HTTP connection") if debug_logger
+
+              http.start do |conn|
+                deliver_requests(conn)
+              end
             rescue => e
-              debug_logger.error("Timber request error: #{e.message}") if debug_logger
+              debug_logger.error("#request_outlet error: #{e.message}") if debug_logger
             ensure
-              debug_logger.debug("Finishing Timber HTTP connection") if debug_logger
+              debug_logger.info("Finishing HTTP connection") if debug_logger
               http.finish if http.started?
             end
           end
@@ -242,29 +253,36 @@ module Timber
           num_reqs = 0
 
           while num_reqs < @requests_per_conn
-            if debug_logger
-              debug_logger.debug("Waiting on next Timber request")
-              debug_logger.debug("Number of threads waiting on Timber request queue: #{@request_queue.num_waiting}")
-            end
+            debug_logger.info("Waiting on next request, threads waiting: #{@request_queue.num_waiting}") if debug_logger
 
             # Blocks waiting for a request.
             req = @request_queue.deq
             @requests_in_flight += 1
-            resp = nil
 
             begin
               resp = conn.request(req)
             rescue => e
-              debug_logger.error("Timber request error: #{e.message}") if debug_logger
+              debug_logger.error("#deliver_request error: #{e.message}") if debug_logger
 
-              # If we error, let's return and let the caller build a new connection
-              return
+              @successive_error_count += 1
+
+              # Back off so that we don't hammer the Timber API.
+              calculated_backoff = @successive_error_count * 2
+              backoff = calculated_backoff > 30 ? 30 : calculated_backoff
+
+              debug_logger.error("Backing off #{backoff} seconds, error ##{@successive_error_count}") if debug_logger
+
+              sleep backoff
+
+              # Throw the request back on the queue for a retry
+              @request_queue.enq(req)
+              return false
             ensure
               @requests_in_flight -= 1
             end
 
             num_reqs += 1
-            debug_logger.debug("Timber request successful: #{resp.code}") if debug_logger
+            debug_logger.info("Request successful: #{resp.code}") if debug_logger
           end
         end
 

--- a/lib/timber/logger/metadata_methods.rb
+++ b/lib/timber/logger/metadata_methods.rb
@@ -1,1 +1,0 @@
-metadata_methods.rb

--- a/spec/support/timber.rb
+++ b/spec/support/timber.rb
@@ -2,4 +2,3 @@ require "timber"
 
 config = Timber::Config.instance
 config.append_metadata = true
-config.debug_to_stdout

--- a/spec/support/timber.rb
+++ b/spec/support/timber.rb
@@ -2,5 +2,4 @@ require "timber"
 
 config = Timber::Config.instance
 config.append_metadata = true
-logger = ::Logger.new(nil)
-config.debug_logger = logger
+config.debug_to_stdout

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -107,9 +107,9 @@ describe Timber::LogDevices::HTTP do
       http = described_class.new("MYKEY", flush_interval: 0.1)
       http.send(:ensure_flush_threads_are_started)
       expect(http).to receive(:flush).exactly(1).times
-      sleep 0.12 # too fast!
+      sleep 0.15 # too fast!
       expect(http).to receive(:flush).exactly(2).times
-      sleep 0.12 # too fast!
+      sleep 0.15 # too fast!
       http.close
     end
   end
@@ -135,7 +135,7 @@ describe Timber::LogDevices::HTTP do
       http.write(log_entry)
       log_entry = Timber::LogEntry.new("INFO", time, nil, "test log message 2", nil, nil)
       http.write(log_entry)
-      sleep 0.3
+      sleep 0.5
 
       expect(stub).to have_been_requested.times(1)
     end

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -108,8 +108,9 @@ describe Timber::LogDevices::HTTP do
       http.send(:ensure_flush_threads_are_started)
       expect(http).to receive(:flush).exactly(1).times
       sleep 0.12 # too fast!
-      expect(http).to receive(:flush).exactly(1).times
+      expect(http).to receive(:flush).exactly(2).times
       sleep 0.12 # too fast!
+      http.close
     end
   end
 

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -44,8 +44,9 @@ describe Timber::LogDevices::HTTP do
 
       it "should attempt a delivery when the limit is exceeded" do
         http.write("test")
-        expect(http).to receive(:flush).exactly(2).times
+        expect(http).to receive(:flush).exactly(1).times
         http.write("my log message")
+        expect(http).to receive(:flush).exactly(1).times
         http.close
       end
     end
@@ -108,8 +109,9 @@ describe Timber::LogDevices::HTTP do
       http.send(:ensure_flush_threads_are_started)
       expect(http).to receive(:flush).exactly(1).times
       sleep 0.15 # too fast!
-      expect(http).to receive(:flush).exactly(2).times
+      expect(http).to receive(:flush).exactly(1).times
       sleep 0.15 # too fast!
+      expect(http).to receive(:flush).exactly(1).times
       http.close
     end
   end

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -137,7 +137,7 @@ describe Timber::LogDevices::HTTP do
       http.write(log_entry)
       log_entry = Timber::LogEntry.new("INFO", time, nil, "test log message 2", nil, nil)
       http.write(log_entry)
-      sleep 0.5
+      sleep 2
 
       expect(stub).to have_been_requested.times(1)
     end

--- a/spec/timber/log_devices/http_spec.rb
+++ b/spec/timber/log_devices/http_spec.rb
@@ -107,11 +107,8 @@ describe Timber::LogDevices::HTTP do
     it "should start a intervaled flush thread and flush on an interval" do
       http = described_class.new("MYKEY", flush_interval: 0.1)
       http.send(:ensure_flush_threads_are_started)
-      expect(http).to receive(:flush).exactly(1).times
-      sleep 0.15 # too fast!
-      expect(http).to receive(:flush).exactly(1).times
-      sleep 0.15 # too fast!
-      expect(http).to receive(:flush).exactly(1).times
+      expect(http).to receive(:flush).exactly(2).times
+      sleep 0.12 # too fast!
       http.close
     end
   end


### PR DESCRIPTION
This PR handles request errors by closing the current HTTP connection and allowing the outlet loop to build a new connection. This is needed for errors like "Conn close because of keep_alive_timeout".