### PR TITLE
For Rails 3, fix ActiveSupport::TaggedLogging to not redefine the public Logger API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ gemfile:
 - gemfiles/rails-4.2.gemfile
 - gemfiles/rails-4.2.gemfile
 - gemfiles/rails-5.0.gemfile
+- gemfiles/rails-5.1.gemfile
 - gemfiles/rails-edge.gemfile
 env:
   global: RAILS_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ matrix:
   - rvm: jruby
     gemfile: gemfiles/rails-5.0.gemfile
   - rvm: jruby
+    gemfile: gemfiles/rails-5.1.gemfile
+  - rvm: jruby
     gemfile: gemfiles/rails-edge.gemfile
 notifications:
   email: false

--- a/gemfiles/rails-5.1.gemfile
+++ b/gemfiles/rails-5.1.gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 5.1.0'
+
+if RUBY_PLATFORM == "java"
+  gem 'mime-types', '2.6.2'
+end
+
+gemspec :path => '../'

--- a/lib/timber/config.rb
+++ b/lib/timber/config.rb
@@ -37,7 +37,7 @@ module Timber
     # This is useful for debugging. This Sets a debug_logger to view internal Timber library
     # log messages. The default is `nil`. Meaning log to nothing.
     #
-    # See `debug_to_file` and `debug_to_stdout` for convenience methods that handle creating
+    # See {#debug_to_file} and {#debug_to_stdout} for convenience methods that handle creating
     # and setting the logger.
     #
     # @example Rails

--- a/lib/timber/contexts.rb
+++ b/lib/timber/contexts.rb
@@ -9,7 +9,7 @@ require "timber/contexts/user"
 module Timber
   # Namespace for all Timber supported Contexts.
   module Contexts
-    # Protocol for casting objects into a `Timber::Context`.
+    # Protocol for casting objects into a {Timber::Context}.
     #
     # @example Casting a hash
     #   Timber::Contexts.build(deploy: {version: "1.0.0"})

--- a/lib/timber/contexts/session.rb
+++ b/lib/timber/contexts/session.rb
@@ -2,7 +2,7 @@ module Timber
   module Contexts
     # The session context tracks the current session for the given user.
     #
-    # @note This is tracked automatically with the `Integrations::Rack::SessionContext` rack
+    # @note This is tracked automatically with the {Integrations::Rack::SessionContext} rack
     #   middleware.
     class Session < Context
       @keyspace = :session

--- a/lib/timber/contexts/user.rb
+++ b/lib/timber/contexts/user.rb
@@ -2,7 +2,7 @@ module Timber
   module Contexts
     # The user context tracks the currently authenticated user.
     #
-    # @note This is tracked automatically with the `Integrations::Rack::UserContext` rack
+    # @note This is tracked automatically with the {Integrations::Rack::UserContext} rack
     #   middleware.
     class User < Context
       @keyspace = :user

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -17,7 +17,7 @@ module Timber
     # @param context_snapshot [Hash] structured data representing a snapshot of the context at
     #   the given point in time.
     # @param event [Timber.Event] structured data representing the log line event. This should be
-    #   an instance of `Timber.Event`.
+    #   an instance of {Timber.Event}.
     # @return [LogEntry] the resulting LogEntry object
     def initialize(level, time, progname, message, context_snapshot, event, options = {})
       @level = level
@@ -92,9 +92,9 @@ module Timber
         event_type = event_hash.keys.first
 
         event_type = if event.is_a?(Events::Custom)
-          "event:#{event_type}.#{event.type}"
+          "#{event_type}.#{event.type}"
         else
-          "event:#{event_type}"
+          "#{event_type}"
         end
 
         log_message = "#{message} [#{event_type}]"

--- a/lib/timber/overrides.rb
+++ b/lib/timber/overrides.rb
@@ -1,3 +1,4 @@
+require "timber/overrides/active_support_tagged_logging"
 require "timber/overrides/lograge"
 require "timber/overrides/rails_stdout_logging"
 

--- a/lib/timber/overrides/active_support_tagged_logging.rb
+++ b/lib/timber/overrides/active_support_tagged_logging.rb
@@ -1,0 +1,103 @@
+# This patch is specifically for Rails 3. The legacy approach to wrapping the logger in
+# ActiveSupport::TaggedLogging is rather poor, hence the reason it was changed entirely
+# for Rails 4 and 5. The problem is that ActiveSupport::TaggedLogging is a wrapping
+# class that entirely redefines the public API for the logger. As a result, any deviations
+# from this API in the logger are not exposed (such as accepting event data as a second argument).
+# This is assuming, so we're fixing it here.
+
+begin
+  require "active_support/tagged_logging"
+
+  # Instead of patching the class we're pulling the code from Rails master. This brings in
+  # a number of improvements while also addressing the issue above.
+  if ActiveSupport::TaggedLogging.instance_of?(Class)
+    ActiveSupport.send(:remove_const, :TaggedLogging)
+
+    require "active_support/core_ext/module/delegation"
+    require "active_support/core_ext/object/blank"
+    require "logger"
+
+    module ActiveSupport
+      # Wraps any standard Logger object to provide tagging capabilities.
+      #
+      #   logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+      #   logger.tagged('BCX') { logger.info 'Stuff' }                            # Logs "[BCX] Stuff"
+      #   logger.tagged('BCX', "Jason") { logger.info 'Stuff' }                   # Logs "[BCX] [Jason] Stuff"
+      #   logger.tagged('BCX') { logger.tagged('Jason') { logger.info 'Stuff' } } # Logs "[BCX] [Jason] Stuff"
+      #
+      # This is used by the default Rails.logger as configured by Railties to make
+      # it easy to stamp log lines with subdomains, request ids, and anything else
+      # to aid debugging of multi-user production applications.
+      module TaggedLogging
+        module Formatter # :nodoc:
+          # This method is invoked when a log event occurs.
+          def call(severity, timestamp, progname, msg)
+            super(severity, timestamp, progname, "#{tags_text}#{msg}")
+          end
+
+          def tagged(*tags)
+            new_tags = push_tags(*tags)
+            yield self
+          ensure
+            pop_tags(new_tags.size)
+          end
+
+          def push_tags(*tags)
+            tags.flatten.reject(&:blank?).tap do |new_tags|
+              current_tags.concat new_tags
+            end
+          end
+
+          def pop_tags(size = 1)
+            current_tags.pop size
+          end
+
+          def clear_tags!
+            current_tags.clear
+          end
+
+          def current_tags
+            # We use our object ID here to avoid conflicting with other instances
+            thread_key = @thread_key ||= "activesupport_tagged_logging_tags:#{object_id}".freeze
+            Thread.current[thread_key] ||= []
+          end
+
+          def tags_text
+            tags = current_tags
+            if tags.any?
+              tags.collect { |tag| "[#{tag}] " }.join
+            end
+          end
+        end
+
+        # Simple formatter which only displays the message.
+        class SimpleFormatter < ::Logger::Formatter
+          # This method is invoked when a log event occurs
+          def call(severity, timestamp, progname, msg)
+            "#{String === msg ? msg : msg.inspect}\n"
+          end
+        end
+
+        def self.new(logger)
+          # Ensure we set a default formatter so we aren't extending nil!
+          logger.formatter ||= SimpleFormatter.new
+          logger.formatter.extend Formatter
+          logger.extend(self)
+        end
+
+        delegate :push_tags, :pop_tags, :clear_tags!, to: :formatter
+
+        def tagged(*tags)
+          formatter.tagged(*tags) { yield self }
+        end
+
+        def flush
+          clear_tags!
+          super if defined?(super)
+        end
+      end
+    end
+  end
+
+rescue Exception
+end

--- a/spec/rails/tagged_logging_spec.rb
+++ b/spec/rails/tagged_logging_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+# ActiveSupport::TaggedLogging is not defined in <= 3.1
+if defined?(::ActiveSupport::TaggedLogging)
+  describe ActiveSupport::TaggedLogging, :rails_23 => true do
+    describe "#info" do
+      let(:time) { Time.utc(2016, 9, 1, 12, 0, 0) }
+      let(:io) { StringIO.new }
+      let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
+
+      around(:each) do |example|
+        Timecop.freeze(time) { example.run }
+      end
+
+      it "should format properly with events" do
+        event = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
+        logger.tagged("tag") do
+          logger.info(event)
+        end
+        expect(io.string).to include("\"tags\":[\"tag\"]")
+      end
+
+      it "should accept events as the second argument" do
+        logger.info("SQL query", payment_rejected: {customer_id: "abcd1234", amount: 100, reason: "Card expired"})
+        expect(io.string).to start_with("SQL query @metadata")
+        expect(io.string).to include("\"event\":{\"custom\":{\"payment_rejected\":")
+      end
+    end
+  end
+end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -100,20 +100,6 @@ describe Timber::Logger, :rails_23 => true do
       end
     end
 
-    if defined?(ActiveSupport::TaggedLogging)
-      context "with TaggedLogging", :rails_23 => false do
-        let(:logger) { ActiveSupport::TaggedLogging.new(Timber::Logger.new(io)) }
-
-        it "should format properly with events" do
-          message = Timber::Events::SQLQuery.new(sql: "select * from users", time_ms: 56, message: "select * from users")
-          logger.tagged("tag") do
-            logger.info(message)
-          end
-          expect(io.string).to include("\"tags\":[\"tag\"]")
-        end
-      end
-    end
-
     context "with the HTTP log device" do
       let(:io) { Timber::LogDevices::HTTP.new("my_key") }
 


### PR DESCRIPTION
This patch is specifically for Rails 3. The legacy approach to wrapping the logger in ActiveSupport::TaggedLogging is rather poor, hence the reason it was changed entirely for Rails 4 and 5. The problem is that ActiveSupport::TaggedLogging is a wrapping class that entirely redefines the public API for the logger. As a result, any deviations from this API in the logger are not exposed (such as accepting event data as a second argument). This is assuming, so we're fixing it here.