### PR TITLE
Only normalize header values that are strings

### DIFF
--- a/lib/timber/util/string.rb
+++ b/lib/timber/util/string.rb
@@ -9,7 +9,7 @@ module Timber
         if string.encoding.to_s == UTF8
           string
         else
-          string.encode('UTF-8', {
+          string.encode(UTF8, {
             :invalid => :replace,
             :undef   => :replace,
             :replace => '?'

--- a/spec/timber/util/http_event_spec.rb
+++ b/spec/timber/util/http_event_spec.rb
@@ -6,5 +6,10 @@ describe Timber::Util::HTTPEvent, :rails_23 => true do
       result = described_class.normalize_headers({"key" => nil})
       expect(result).to eq({"key" => nil})
     end
+
+    it "should handle non strings" do
+      result = described_class.normalize_headers({"key" => 1})
+      expect(result).to eq({"key" => 1})
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/timberio/timber-ruby/issues/91