### PR TITLE
Accept symbols for Logger#level=

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,13 @@ logger.info("Processed background job", background_job: {time_ms: timer})
 # => Processed background job in 54.2ms @metadata {"level": "info", "event": {"background_job": {"time_ms": 54.2}}}
 ```
 
-Or capture any metric you want:
+And of course, `time_ms` can also take a `Float`:
+
+```ruby
+logger.info("Processed background job", background_job: {time_ms: 45.6})
+```
+
+Lastly, metrics aren't limited to timings. You can capture any metric you want:
 
 ```ruby
 logger = Timber::Logger.new(STDOUT)

--- a/lib/timber/logger.rb
+++ b/lib/timber/logger.rb
@@ -224,7 +224,6 @@ module Timber
     # @note The formatter cannot be changed if you are using the HTTP logger backend.
     def formatter=(value)
       if @initialized && @logdev && @logdev.dev.is_a?(Timber::LogDevices::HTTP) && !value.is_a?(PassThroughFormatter)
-        raise @logdev.inspect
         raise ArgumentError.new("The formatter cannot be changed when using the " +
           "Timber::LogDevices::HTTP log device. The PassThroughFormatter must be used for proper " +
           "delivery.")

--- a/lib/timber/logger.rb
+++ b/lib/timber/logger.rb
@@ -224,11 +224,19 @@ module Timber
     # @note The formatter cannot be changed if you are using the HTTP logger backend.
     def formatter=(value)
       if @initialized && @logdev && @logdev.dev.is_a?(Timber::LogDevices::HTTP) && !value.is_a?(PassThroughFormatter)
+        raise @logdev.inspect
         raise ArgumentError.new("The formatter cannot be changed when using the " +
           "Timber::LogDevices::HTTP log device. The PassThroughFormatter must be used for proper " +
           "delivery.")
       end
 
+      super
+    end
+
+    def level=(value)
+      if value.is_a?(Symbol)
+        value = level_from_symbol(value)
+      end
       super
     end
 
@@ -269,6 +277,18 @@ module Timber
       def environment_level
         level = ([ENV['LOG_LEVEL'].to_s.upcase, "DEBUG"] & %w[DEBUG INFO WARN ERROR FATAL UNKNOWN]).compact.first
         self.class.const_get(level)
+      end
+
+      def level_from_symbol(value)
+        case value
+        when :debug; DEBUG
+        when :info;  INFO
+        when :warn;  WARN
+        when :error; ERROR
+        when :fatal; FATAL
+        when :unknown; UNKNOWN
+        else; raise ArgumentError.new("level #{value.inspect} is not a valid logger level")
+        end
       end
   end
 end


### PR DESCRIPTION
Rails accepts symbols when setting the Rails configuration:

```
config.log_level = :debug
```

This is a little misleading because they then extract the constant [here](ActiveSupport::Logger.const_get(config.log_level.to_s.upcase). Instead of doing the same, we're going to support symbols for `Timber::Logger#level=` since this feels more user friendly, especially since Rails introduces the concept of symboled levels.

Closes https://github.com/timberio/timber-ruby/issues/98