### PR TITLE
Add new job context for tracking background jobs / tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ For a complete overview, see the [Timber for Ruby docs](https://timber.io/docs/r
 
 ## Third-party integrations
 
-1. **Rails**: Structures ([HTTP requests](https://timber.io/docs/ruby/events-and-context/http-server-request-event/), [HTTP respones](https://timber.io/docs/ruby/events-and-context/http-server-response-event/), [controller calls](https://timber.io/docs/ruby/events-and-context/controller-call-event/), [template renders](https://timber.io/docs/ruby/events-and-context/template-render-event/), and [sql queries](https://timber.io/docs/ruby/events-and-context/sql-query-event/)).
-2. **Rack**: Structures [exceptions](https://timber.io/docs/ruby/events-and-context/exception-event/), captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/), captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/), captures [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
+1. **Rails**: Automatically structures ([HTTP request events](https://timber.io/docs/ruby/events-and-context/http-server-request-event/), [HTTP response events](https://timber.io/docs/ruby/events-and-context/http-server-response-event/), [controller call events](https://timber.io/docs/ruby/events-and-context/controller-call-event/), [template rendering events](https://timber.io/docs/ruby/events-and-context/template-render-event/), and [sql query events](https://timber.io/docs/ruby/events-and-context/sql-query-event/)).
+2. **Rack**: Automatically structures [exception events](https://timber.io/docs/ruby/events-and-context/exception-event/), captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/), captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/), captures [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
 3. **Devise, Omniauth, Clearance**: captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/)
-5. **Heroku**: Captures [release context](https://timber.io/docs/ruby/events-and-context/release-context/) via [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).
+5. **Heroku**: Automatically captures [release context](https://timber.io/docs/ruby/events-and-context/release-context/) via [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).
 
 ...and more. Timber will continue to evolve and support more libraries.
 
@@ -195,13 +195,7 @@ end
 
 <details><summary><strong>Metrics & Timings</strong></summary><p>
 
-Aggregates destroy details, and with Timber capturing metrics and timings is just logging events.
-Timber is built on modern big-data principles, it can calculate aggregates across terrabytes of
-data in seconds. Don't reduce the quality of your log data to accomodate a restrive
-logging system.
-
-Here's a timing example. Notice how Timber automatically calculates the time and adds the timing
-to the message.
+Aggregates destroy details, and with Timber capturing metrics and timings is just logging events. Below is a timing example. Notice how Timber automatically calculates the time:
 
 ```ruby
 logger = Timber::Logger.new(STDOUT)
@@ -212,13 +206,13 @@ logger.info("Processed background job", background_job: {time_ms: timer})
 # => Processed background job in 54.2ms @metadata {"level": "info", "event": {"background_job": {"time_ms": 54.2}}}
 ```
 
-And of course, `time_ms` can also take a `Float` or `Fixnum`:
+`time_ms` can also take a `Float` or `Fixnum`:
 
 ```ruby
 logger.info("Processed background job", background_job: {time_ms: 45.6})
 ```
 
-Lastly, metrics aren't limited to timings. You can capture any metric you want:
+Lastly, metrics aren't limited to timings, capture any metric you want:
 
 ```ruby
 logger = Timber::Logger.new(STDOUT)
@@ -227,8 +221,7 @@ logger.info("Credit card charged", credit_card_charge: {amount: 123.23})
 # => Credit card charged @metadata {"level": "info", "event": {"credit_card_charge": {"amount": 123.23}}}
 ```
 
-In Timber you can easily sum, average, min, and max the `amount` attribute across any interval
-you desire.
+In Timber you can easily perform aggreates on any numerical data type. For example, sum, average, min, and max the `amount` attribute across any interval you desire.
 
 </p></details>
 

--- a/README.md
+++ b/README.md
@@ -124,10 +124,13 @@ For a complete overview, see the [Timber for Ruby docs](https://timber.io/docs/r
 
 ## Third-party integrations
 
-1. **Rails**: Automatically structures ([HTTP request events](https://timber.io/docs/ruby/events-and-context/http-server-request-event/), [HTTP response events](https://timber.io/docs/ruby/events-and-context/http-server-response-event/), [controller call events](https://timber.io/docs/ruby/events-and-context/controller-call-event/), [template rendering events](https://timber.io/docs/ruby/events-and-context/template-render-event/), and [sql query events](https://timber.io/docs/ruby/events-and-context/sql-query-event/)).
-2. **Rack**: Automatically structures [exception events](https://timber.io/docs/ruby/events-and-context/exception-event/), captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/), captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/), captures [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
-3. **Devise, Omniauth, Clearance**: captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/)
-5. **Heroku**: Automatically captures [release context](https://timber.io/docs/ruby/events-and-context/release-context/) via [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).
+1. **Rack**: Automatically structures ([HTTP request events](https://timber.io/docs/ruby/events-and-context/http-server-request-event/), [HTTP response events](https://timber.io/docs/ruby/events-and-context/http-server-response-event/), [exception events](https://timber.io/docs/ruby/events-and-context/exception-event/). Also captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/) and [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
+2. **ActionController (Rails)**: Automatically structures [controller call events](https://timber.io/docs/ruby/events-and-context/controller-call-event/)
+3. **ActionView (Rails)**: Automatically structures [template rendering events](https://timber.io/docs/ruby/events-and-context/template-render-event/)
+4. **ActiveRecord (Rails)**: Automatically structures [sql query events](https://timber.io/docs/ruby/events-and-context/sql-query-event/)).
+5. **ActiveJob (Rails)**: Automatically captures [job context](https://timber.io/docs/ruby/events-and-context/job-context/).
+6. **Devise, Omniauth, Clearance**: Automatically captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/) via the [UserContext rack middleware](http://www.rubydoc.info/github/timberio/timber-ruby/Timber/Integrations/Rack/UserContext).
+7. **Heroku**: Automatically captures [release context](https://timber.io/docs/ruby/events-and-context/release-context/) via [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).
 
 ...and more. Timber will continue to evolve and support more libraries.
 
@@ -195,7 +198,8 @@ end
 
 <details><summary><strong>Metrics & Timings</strong></summary><p>
 
-Aggregates destroy details, and with Timber capturing metrics and timings is just logging events. Below is a timing example. Notice how Timber automatically calculates the time:
+Aggregates destroy details, and with Timber capturing metrics and timings is just logging events.
+Below is a timing example. Notice how Timber automatically calculates the time:
 
 ```ruby
 logger = Timber::Logger.new(STDOUT)
@@ -221,7 +225,15 @@ logger.info("Credit card charged", credit_card_charge: {amount: 123.23})
 # => Credit card charged @metadata {"level": "info", "event": {"credit_card_charge": {"amount": 123.23}}}
 ```
 
-In Timber you can easily perform aggreates on any numerical data type. For example, sum, average, min, and max the `amount` attribute across any interval you desire.
+In Timber you can easily perform aggreates on any numerical data type. For example:
+
+1. `sum(background_job.time_ms)`
+2. `avg(background_job.time_ms)`
+3. `min(background_job.time_ms)`
+4. `max(background_job.time_ms)`
+
+...and more. The Timber console allows you to run aggregates as a whole or as a histogram
+across any time interval you desire.
 
 </p></details>
 

--- a/lib/timber/contexts.rb
+++ b/lib/timber/contexts.rb
@@ -1,5 +1,6 @@
 require "timber/contexts/custom"
 require "timber/contexts/http"
+require "timber/contexts/job"
 require "timber/contexts/organization"
 require "timber/contexts/release"
 require "timber/contexts/runtime"

--- a/lib/timber/contexts/job.rb
+++ b/lib/timber/contexts/job.rb
@@ -1,0 +1,32 @@
+require "timber/context"
+require "timber/util"
+
+module Timber
+  module Contexts
+    # The job context tracks job or task execution.
+    #
+    # @note This is tracked automatically in {Integrations::ActiveJob}. If you are not using
+    #   `ActiveJob` you can easily add this yourself. See example.
+    #
+    # @example Track jobs / tasks manually
+    #   # See note above, this might be tracked automatically.
+    #   job_context = Timber::Contexts::Job.new(id: "my_job_id")
+    #   logger.with_context(job_context) do
+    #     # anything logged here will have the job context included.
+    #   end
+    class Job < Context
+      @keyspace = :job
+
+      attr_reader :id
+
+      def initialize(attributes)
+        @id = attributes[:id]
+      end
+
+      # Builds a hash representation containing simple objects, suitable for serialization (JSON).
+      def as_json(_options = {})
+        {id: Timber::Util::Object.try(id, :to_s)}
+      end
+    end
+  end
+end

--- a/lib/timber/contexts/system.rb
+++ b/lib/timber/contexts/system.rb
@@ -3,7 +3,7 @@ require "timber/util"
 
 module Timber
   module Contexts
-    # The system context tracks OS level process information, such as the process ID.
+    # The system context tracks OS level information, such as the process ID and hostname.
     #
     # @note This is tracked automatically in {CurrentContext}. When the current context
     #   is initialized, the system context gets added automatically.

--- a/lib/timber/contexts/user.rb
+++ b/lib/timber/contexts/user.rb
@@ -8,8 +8,8 @@ module Timber
     # filter and tail logs by specific users.
     #
     # @note This is tracked automatically with the {Integrations::Rack::UserContext} rack
-    #   middleware for supported authentication frameworks. See {Integrations::Rack::UserContext}
-    #   for more details.
+    #   middleware and it can be configured for custom integrations.
+    #   See {Integrations::Rack::UserContext} for more details.
     class User < Context
       @keyspace = :user
 

--- a/lib/timber/integrations.rb
+++ b/lib/timber/integrations.rb
@@ -1,6 +1,7 @@
 require "timber/integrations/action_controller"
 require "timber/integrations/action_dispatch"
 require "timber/integrations/action_view"
+require "timber/integrations/active_job"
 require "timber/integrations/active_record"
 require "timber/integrations/rack"
 require "timber/integrations/rails"
@@ -13,6 +14,7 @@ module Timber
     def self.enabled=(value)
       ActionController.enabled = value
       ActionView.enabled = value
+      ActiveJob.enabled = value
       ActiveRecord.enabled = value
       Rack.enabled = value
     end
@@ -22,6 +24,7 @@ module Timber
       ActionController.integrate!
       ActionDispatch.integrate!
       ActionView.integrate!
+      ActiveJob.integrate!
       ActiveRecord.integrate!
       Rails.integrate!
     end

--- a/lib/timber/integrations/action_dispatch/debug_exceptions.rb
+++ b/lib/timber/integrations/action_dispatch/debug_exceptions.rb
@@ -10,7 +10,9 @@ module Timber
       # @private
       class DebugExceptions < Integrator
 
-        # Patch for disabling logging
+        # Patch for disabling logging *only*. This leaves the rest of the class
+        # intact since it performs other functions, like displaying the user friendly
+        # exception screen in development.
         #
         # @private
         module InstanceMethods

--- a/lib/timber/integrations/active_job.rb
+++ b/lib/timber/integrations/active_job.rb
@@ -1,0 +1,18 @@
+require "timber/integration"
+require "timber/integrations/active_job/job_contet"
+
+module Timber
+  module Integrations
+    # Module for holding *all* ActiveJob integrations. See {Integration} for
+    # configuration details for all integrations.
+    module ActiveJob
+      extend Integration
+
+      def self.integrate!
+        return false if !enabled?
+
+        JobContext.integrate!
+      end
+    end
+  end
+end

--- a/lib/timber/integrations/active_job/job_context.rb
+++ b/lib/timber/integrations/active_job/job_context.rb
@@ -1,0 +1,32 @@
+module Timber
+  module Integrations
+    module ActiveJob
+      class JobContext < Integrator
+        module AddJobContext
+          def self.included(klass)
+            klass.class_eval do
+              around_perform do |job, block, _|
+                context = Contexts::Job.new(id: job.job_id)
+                CurrentContext.with(context) do
+                  block.call
+                end
+              end
+            end
+          end
+        end
+
+        def initialize
+          require "active_job"
+        rescue LoadError => e
+          raise RequirementNotMetError.new(e.message)
+        end
+
+        def integrate!
+          if defined?(::ActiveJob::Base) && !::ActiveJob::Base.include?(AddJobContext)
+            ::ActiveJob::Base.send(:include, AddJobContext)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -50,6 +50,7 @@ if defined?(::Rails)
         ::ActionController::Base.logger = logger if defined?(::ActionController::Base) && ::ActionController::Base.respond_to?(:logger=)
         ::ActionMailer::Base.logger = logger if defined?(::ActionMailer::Base) && ::ActionMailer::Base.respond_to?(:logger=)
         ::ActionView::Base.logger = logger if defined?(::ActionView::Base) && ::ActionView::Base.respond_to?(:logger=)
+        ::ActiveJob::Base.logger = logger if defined?(::ActiveJob::Base) && ::ActiveJob::Base.respond_to?(:logger=)
         ::ActiveRecord::Base.logger = logger if defined?(::ActiveRecord::Base) && ::ActiveRecord::Base.respond_to?(:logger=)
         ::Rails.logger = logger
 


### PR DESCRIPTION
This adds the new `job` context for tracking background job and task executions. It automatically integrates with `ActiveJob` and provides an example to track jobs through other frameworks as well.