### PR TITLE
Be more defensive with exception line parsing

### DIFF
--- a/lib/timber/events/exception.rb
+++ b/lib/timber/events/exception.rb
@@ -41,9 +41,20 @@ module Timber
         def parse_backtrace_line(line)
           # using split for performance reasons
           file, line, function_part = line.split(":", 3)
-          _prefix, function_pre = function_part.split("`", 2)
-          function = Util::Object.try(function_pre, :chomp, "'")
-          {file: file, line: line.to_i, function: function}
+
+          parsed_line = {file: file}
+
+          if line
+            parsed_line[:line] = line.to_i
+          end
+
+          if function_part
+            _prefix, function_pre = function_part.split("`", 2)
+            function = Util::Object.try(function_pre, :chomp, "'")
+            parsed_line[:function] = function
+          end
+
+          parsed_line
         end
     end
   end

--- a/spec/timber/events/exception_spec.rb
+++ b/spec/timber/events/exception_spec.rb
@@ -11,5 +11,24 @@ describe Timber::Events::Exception, :rails_23 => true do
       exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
       expect(exception_event.backtrace).to eq([{:file=>"/path/to/file1.rb", :line=>26, :function=>"function1"}, {:file=>"path/to/file2.rb", :line=>86, :function=>"function2"}])
     end
+
+    it "parses valid lines" do
+      backtrace = [
+        "/path/to/file1.rb:26:in `function1'",
+        "path/to/file2.rb:86" # function names are optional
+      ]
+
+      exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
+      expect(exception_event.backtrace).to eq([{:file=>"/path/to/file1.rb", :line=>26, :function=>"function1"}, {:file=>"path/to/file2.rb", :line=>86}])
+    end
+
+    it "handles malformed lines" do
+      backtrace = [
+        "malformed"
+      ]
+
+      exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
+      expect(exception_event.backtrace).to eq([{:file=>"malformed"}])
+   end
   end
 end


### PR DESCRIPTION
According to the [ruby docs](https://ruby-doc.org/core-2.2.0/Exception.html#method-i-backtrace):

> The backtrace is an array of strings, each containing either “filename:lineNo: in `method”‘ or “filename:lineNo.”

This accounts for the 2 formats mentioned as well as being defensive for unknown formats.