### PR TITLE
Enforce JSON schema byte limits

### DIFF
--- a/lib/timber/config.rb
+++ b/lib/timber/config.rb
@@ -36,7 +36,7 @@ module Timber
 
     # @private
     def initialize
-      @http_body_limit = 2000
+      @http_body_limit = 2048
     end
 
     # Convenience method for logging debug statements to the debug logger
@@ -130,16 +130,15 @@ module Timber
       @http_header_filters ||= []
     end
 
-    # Truncates captured HTTP bodies to this specified limit. The default is `2000`.
-    # If you want to capture more data, you can raise this to a maximum of `5000`,
-    # or lower this to be more efficient with data. `2000` characters should give you a good
-    # idea of the body content. If you need to raise to `5000` you're only constraint is
-    # network throughput.
+    # Truncates captured HTTP bodies to this specified limit. The default is `2048`.
+    # If you want to capture more data, you can raise this to a maximum of `8192`,
+    # or lower this to be more efficient with data. `2048` characters should give you a good
+    # idea of the body content.
     #
     # @example Rails
-    #   config.timber.http_body_limit = 500
+    #   config.timber.http_body_limit = 2048
     # @example Everything else
-    #   Timber::Config.instance.http_body_limit = 500
+    #   Timber::Config.instance.http_body_limit = 2048
     def http_body_limit=(value)
       @http_body_limit = value
     end

--- a/lib/timber/events/controller_call.rb
+++ b/lib/timber/events/controller_call.rb
@@ -10,6 +10,7 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionController::LogSubscriber} integration.
     class ControllerCall < Timber::Event
+      PARAMS_JSON_MAX_BYTES = 8192.freeze
       PASSWORD_NAME = 'password'.freeze
 
       attr_reader :controller, :action, :params, :format
@@ -44,11 +45,12 @@ module Timber
 
       private
         def params_json
-          @params_json ||= if params.nil? || params == {}
-            nil
-          else
-            params.to_json
-          end
+          @params_json ||=
+            if params.nil? || params == {}
+              nil
+            else
+              params.to_json.byteslice(0, PARAMS_JSON_MAX_BYTES)
+            end
         end
 
         def sanitize_params(params)

--- a/lib/timber/events/exception.rb
+++ b/lib/timber/events/exception.rb
@@ -8,11 +8,15 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionDispatch::DebugExceptions} integration.
     class Exception < Timber::Event
+      MAX_MESSAGE_BYTES = 8192.freeze
+
       attr_reader :name, :exception_message, :backtrace
 
       def initialize(attributes)
         @name = attributes[:name] || raise(ArgumentError.new(":name is required"))
+
         @exception_message = attributes[:exception_message] || raise(ArgumentError.new(":exception_message is required"))
+        @exception_message = @exception_message.byteslice(0, MAX_MESSAGE_BYTES)
 
         backtrace = attributes[:backtrace]
         if backtrace.nil? || backtrace == []

--- a/lib/timber/events/sql_query.rb
+++ b/lib/timber/events/sql_query.rb
@@ -7,10 +7,13 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActiveRecord::LogSubscriber} integration.
     class SQLQuery < Timber::Event
+      MAX_QUERY_BYTES = 1024.freeze
+
       attr_reader :sql, :time_ms, :message
 
       def initialize(attributes)
         @sql = attributes[:sql] || raise(ArgumentError.new(":sql is required"))
+        @sql = @sql.byteslice(0, MAX_QUERY_BYTES)
         @time_ms = attributes[:time_ms] || raise(ArgumentError.new(":time_ms is required"))
         @time_ms = @time_ms.round(6)
         @message = attributes[:message] || raise(ArgumentError.new(":message is required"))

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -32,7 +32,7 @@ module Timber
       # This follows the default behavior set by ::Logger
       # See: https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L615
       @message = message.is_a?(String) ? message : message.inspect
-      @message = message.byteslice(0, MESSAGE_MAX_BYTES)
+      @message = @message.byteslice(0, MESSAGE_MAX_BYTES)
       @tags = options[:tags]
       @time_ms = options[:time_ms]
       @context_snapshot = context_snapshot

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -8,7 +8,8 @@ module Timber
   # `Logger` and the log device that you set it up with.
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.0.4/schema.json".freeze
+    MESSAGE_MAX_BYTES = 8192.freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.1.1/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 
@@ -31,6 +32,7 @@ module Timber
       # This follows the default behavior set by ::Logger
       # See: https://github.com/ruby/ruby/blob/trunk/lib/logger.rb#L615
       @message = message.is_a?(String) ? message : message.inspect
+      @message = message.byteslice(0, MESSAGE_MAX_BYTES)
       @tags = options[:tags]
       @time_ms = options[:time_ms]
       @context_snapshot = context_snapshot

--- a/lib/timber/util/http_event.rb
+++ b/lib/timber/util/http_event.rb
@@ -4,7 +4,7 @@ module Timber
     # {Events::HTTPServerResponse}, {Events::HTTPClientRequest}, {Events::HTTPClientResponse}.
     module HTTPEvent
       HEADERS_TO_SANITIZE = ['authorization', 'x-amz-security-token'].freeze
-      QUERY_STRING_LIMIT = 5_000.freeze
+      MAX_QUERY_STRING_BYTES = 2048.freeze
       STRING_CLASS_NAME = 'String'.freeze
 
       extend self
@@ -25,7 +25,7 @@ module Timber
 
         limit = Config.instance.http_body_limit
         if limit
-          body[0..(limit - 1)]
+          body.byteslice(0, limit)
         else
           body
         end
@@ -63,7 +63,7 @@ module Timber
           query_string = query_string.to_s
         end
 
-        query_string && query_string[0..(QUERY_STRING_LIMIT - 1)]
+        query_string && query_string.byteslice(0, MAX_QUERY_STRING_BYTES)
       end
     end
   end


### PR DESCRIPTION
This ensures attributes of the log even adhere to the byte limits specified in the JSON schema.