### PR TITLE
Rename Exception to Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ So what can you do with this data?
 3. **Narrow by host** - `system.hostname:1.server.com`
 4. **View slow responses** - `http_server_response.time_ms:>=1000`
 5. **Filter by log level** - `level:error`
-6. **Quickly find exceptions** - `is:exception`
+6. **Quickly find errors** - `is:error`
 
 For a complete overview, see the [Timber for Ruby docs](https://timber.io/docs/ruby/overview/).
 
@@ -118,7 +118,7 @@ For a complete overview, see the [Timber for Ruby docs](https://timber.io/docs/r
 ## Third-party integrations
 
 1. **Rails**: Structures ([HTTP requests](https://timber.io/docs/ruby/events-and-context/http-server-request-event/), [HTTP respones](https://timber.io/docs/ruby/events-and-context/http-server-response-event/), [controller calls](https://timber.io/docs/ruby/events-and-context/controller-call-event/), [template renders](https://timber.io/docs/ruby/events-and-context/template-render-event/), and [sql queries](https://timber.io/docs/ruby/events-and-context/sql-query-event/)).
-2. **Rack**: Structures [exceptions](https://timber.io/docs/ruby/events-and-context/exception-event/), captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/), captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/), captures [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
+2. **Rack**: Structures [errors](https://timber.io/docs/ruby/events-and-context/error-event/), captures [HTTP context](https://timber.io/docs/ruby/events-and-context/http-context/), captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/), captures [session context](https://timber.io/docs/ruby/events-and-context/session-context/).
 3. **Devise, Omniauth, Clearance**: captures [user context](https://timber.io/docs/ruby/events-and-context/user-context/)
 5. **Heroku**: Captures [release context](https://timber.io/docs/ruby/events-and-context/release-context/) via [Heroku dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata).
 

--- a/lib/timber/config/integrations/rack.rb
+++ b/lib/timber/config/integrations/rack.rb
@@ -14,15 +14,15 @@ module Timber
       module Rack
         extend self
 
-        # Convenience method for accessing the {Timber::Integrations::Rack::ExceptionEvent}
+        # Convenience method for accessing the {Timber::Integrations::Rack::ErrorEvent}
         # middleware class specific configuration. See {Timber::Integrations::Rack::ExceptionEvent}
         # for a list of methods available.
         #
         # @example
         #   config = Timber::Config.instance
-        #   config.integrations.rack.exception_event.enabled = false
-        def exception_event
-          Timber::Integrations::Rack::ExceptionEvent
+        #   config.integrations.rack.error_event.enabled = false
+        def error_event
+          Timber::Integrations::Rack::ErrorEvent
         end
 
         # Convenience method for accessing the {Timber::Integrations::Rack::HTTPContext}

--- a/lib/timber/events.rb
+++ b/lib/timber/events.rb
@@ -1,6 +1,6 @@
 require "timber/events/controller_call"
 require "timber/events/custom"
-require "timber/events/exception"
+require "timber/events/error"
 require "timber/events/http_client_request"
 require "timber/events/http_client_response"
 require "timber/events/http_server_request"

--- a/lib/timber/integrations/action_dispatch.rb
+++ b/lib/timber/integrations/action_dispatch.rb
@@ -1,5 +1,5 @@
 require "timber/integration"
-require "timber/integrations/rack/exception_event"
+require "timber/integrations/rack/error_event"
 require "timber/integrations/action_dispatch/debug_exceptions"
 
 module Timber
@@ -10,7 +10,7 @@ module Timber
     # works as expected.
     module ActionDispatch
       def self.enabled?
-        Rack::ExceptionEvent.enabled?
+        Rack::ErrorEvent.enabled?
       end
 
       def self.integrate!

--- a/lib/timber/integrations/rack.rb
+++ b/lib/timber/integrations/rack.rb
@@ -1,4 +1,4 @@
-require "timber/integrations/rack/exception_event"
+require "timber/integrations/rack/error_event"
 require "timber/integrations/rack/http_context"
 require "timber/integrations/rack/http_events"
 require "timber/integrations/rack/session_context"
@@ -9,7 +9,7 @@ module Timber
     module Rack
       # Enable / disable all Rack middlewares with a single setting.
       def self.enabled=(value)
-        ExceptionEvent.enabled = value
+        ErrorEvent.enabled = value
         HTTPContext.enabled = value
         HTTPEvents.enabled = value
         SessionContext.enabled = value
@@ -20,7 +20,7 @@ module Timber
       # context are added first so that context is included in subsequent log lines.
       def self.middlewares
         @middlewares ||= [HTTPContext, SessionContext, UserContext,
-          HTTPEvents, ExceptionEvent].select(&:enabled?)
+          HTTPEvents, ErrorEvent].select(&:enabled?)
       end
     end
   end

--- a/lib/timber/integrations/rack/error_event.rb
+++ b/lib/timber/integrations/rack/error_event.rb
@@ -7,16 +7,16 @@ rescue Exception
 end
 
 require "timber/config"
-require "timber/events/exception"
+require "timber/events/error"
 require "timber/integrations/rack/middleware"
 require "timber/util"
 
 module Timber
   module Integrations
     module Rack
-      # A Rack middleware that is reponsible for capturing exceptions events
-      # {Timber::Events::Exception}.
-      class ExceptionEvent < Middleware
+      # A Rack middleware that is reponsible for capturing exception and error events
+      # {Timber::Events::Error}.
+      class ErrorEvent < Middleware
         # We determine this when the app loads to avoid the overhead on a per request basis.
         EXCEPTION_WRAPPER_TAKES_CLEANER = if Gem.loaded_specs["rails"]
           Gem.loaded_specs["rails"].version >= Gem::Version.new('5.0.0')
@@ -31,9 +31,9 @@ module Timber
             Config.instance.logger.fatal do
               backtrace = extract_backtrace(env, exception)
 
-              Events::Exception.new(
+              Events::Error.new(
                 name: exception.class.name,
-                exception_message: exception.message,
+                error_message: exception.message,
                 backtrace: backtrace
               )
             end

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -9,7 +9,7 @@ module Timber
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
     MESSAGE_MAX_BYTES = 8192.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.1.1/schema.json".freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v2.4.0/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 

--- a/spec/timber/events/error_spec.rb
+++ b/spec/timber/events/error_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Timber::Events::Exception, :rails_23 => true do
+describe Timber::Events::Error, :rails_23 => true do
   describe ".initialize" do
     it "should clean the backtrace" do
       backtrace = [
@@ -8,7 +8,7 @@ describe Timber::Events::Exception, :rails_23 => true do
         "path/to/file2.rb:86:in `function2'"
       ]
 
-      exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
+      exception_event = described_class.new(name: "RuntimeError", error_message: "Boom", backtrace: backtrace)
       expect(exception_event.backtrace).to eq([{:file=>"/path/to/file1.rb", :line=>26, :function=>"function1"}, {:file=>"path/to/file2.rb", :line=>86, :function=>"function2"}])
     end
 
@@ -18,7 +18,7 @@ describe Timber::Events::Exception, :rails_23 => true do
         "path/to/file2.rb:86" # function names are optional
       ]
 
-      exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
+      exception_event = described_class.new(name: "RuntimeError", error_message: "Boom", backtrace: backtrace)
       expect(exception_event.backtrace).to eq([{:file=>"/path/to/file1.rb", :line=>26, :function=>"function1"}, {:file=>"path/to/file2.rb", :line=>86}])
     end
 
@@ -27,7 +27,7 @@ describe Timber::Events::Exception, :rails_23 => true do
         "malformed"
       ]
 
-      exception_event = described_class.new(name: "RuntimeError", exception_message: "Boom", backtrace: backtrace)
+      exception_event = described_class.new(name: "RuntimeError", error_message: "Boom", backtrace: backtrace)
       expect(exception_event.backtrace).to eq([{:file=>"malformed"}])
    end
   end

--- a/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
@@ -41,7 +41,7 @@ if defined?(::ActionDispatch)
         lines = clean_lines(io.string.split("\n"))
         expect(lines.length).to eq(3)
         expect(lines[2]).to start_with('RuntimeError (boom) @metadata {"level":"fatal",')
-        expect(lines[2]).to include("\"event\":{\"exception\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace\":[")
+        expect(lines[2]).to include("\"event\":{\"error\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace\":[")
       end
 
       # Remove blank lines since Rails does this to space out requests in the logs


### PR DESCRIPTION
This updates the library to use [`2.4.0` of our log event JSON schema](https://github.com/timberio/log-event-json-schema/releases/tag/v2.4.0) renaming `ExceptionEvent` to `ErrorEvent`.