### PR TITLE
Adjust http request requirements

### DIFF
--- a/lib/timber/contexts/system.rb
+++ b/lib/timber/contexts/system.rb
@@ -15,12 +15,12 @@ module Timber
       def initialize(attributes)
         @hostname = attributes[:hostname]
         @pid = attributes[:pid]
-        @pid = @pid.to_s
+        @pid = Timber::Util::Object.try(@pid, :to_i)
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {hostname: hostname, pid: Timber::Util::Object.try(pid, :to_s)}
+        {hostname: hostname, pid: Timber::Util::Object.try(pid, :to_i)}
       end
     end
   end

--- a/lib/timber/events/http_request.rb
+++ b/lib/timber/events/http_request.rb
@@ -15,12 +15,12 @@ module Timber
       def initialize(attributes)
         @body = attributes[:body] && Util::HTTPEvent.normalize_body(attributes[:body])
         @headers = Util::HTTPEvent.normalize_headers(attributes[:headers])
-        @host = attributes[:host] || raise(ArgumentError.new(":host is required"))
+        @host = attributes[:host]
         @method = Util::HTTPEvent.normalize_method(attributes[:method]) || raise(ArgumentError.new(":method is required"))
         @path = attributes[:path]
         @port = attributes[:port]
         @query_string = Util::HTTPEvent.normalize_query_string(attributes[:query_string])
-        @scheme = attributes[:scheme] || raise(ArgumentError.new(":scheme is required"))
+        @scheme = attributes[:scheme]
         @request_id = attributes[:request_id]
       end
 

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -9,7 +9,7 @@ module Timber
   class LogEntry #:nodoc:
     DT_PRECISION = 6.freeze
     MESSAGE_MAX_BYTES = 8192.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.0.3/schema.json".freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.0.7/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 

--- a/spec/timber/contexts/system_spec.rb
+++ b/spec/timber/contexts/system_spec.rb
@@ -3,9 +3,9 @@ require "spec_helper"
 describe Timber::Contexts::System, :rails_23 => true do
   describe ".as_json" do
     it "should coerce pid into an string" do
-      custom_context = described_class.new(:pid => 1)
+      custom_context = described_class.new(:pid => "1")
       json = custom_context.as_json()
-      expect(json[:pid]).to eq("1")
+      expect(json[:pid]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
Adjusts the `HTTPRequest` event requirements to make `host` and `scheme` optional. This follows the [HTTP 1.0 specification](https://www.w3.org/Protocols/HTTP/1.0/spec.html).