### PR TITLE
Use the current thread object_id as the vm_pid

### DIFF
--- a/lib/timber/contexts/runtime.rb
+++ b/lib/timber/contexts/runtime.rb
@@ -9,7 +9,7 @@ module Timber
     class Runtime < Context
       @keyspace = :runtime
 
-      attr_reader :application, :class_name, :file, :function, :line, :module_name
+      attr_reader :application, :class_name, :file, :function, :line, :module_name, :vm_pid
 
       def initialize(attributes)
         @application = attributes[:application]
@@ -18,12 +18,13 @@ module Timber
         @function = attributes[:function]
         @line = attributes[:line]
         @module_name = attributes[:module_name]
+        @vm_pid = attributes[:vm_pid]
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
         {application: application, class_name: class_name, file: file, function: function,
-          line: line, module_name: module_name}
+          line: line, module_name: module_name, vm_pid: vm_pid}
       end
     end
   end

--- a/lib/timber/current_context.rb
+++ b/lib/timber/current_context.rb
@@ -158,6 +158,11 @@ module Timber
         system_context = Contexts::System.new(hostname: hostname, pid: pid)
         add_to!(new_hash, system_context)
 
+        # Runtime context
+        thread_object_id = Thread.current.object_id
+        runtime_context = Contexts::System.new(vm_pid: thread_object_id)
+        add_to!(new_hash, runtime_context)
+
         new_hash
       end
 


### PR DESCRIPTION
This adds the `context.runtime.vm_pid` field making it possible to segment logs by the current thread id.