### PR TITLE
Allow logging to multiple devices

### DIFF
--- a/lib/timber/log_devices.rb
+++ b/lib/timber/log_devices.rb
@@ -1,4 +1,5 @@
 require "timber/log_devices/http"
+require "timber/log_devices/multi"
 
 module Timber
   # Namespace for all log devices.

--- a/lib/timber/log_devices/multi.rb
+++ b/lib/timber/log_devices/multi.rb
@@ -1,0 +1,34 @@
+module Timber
+  module LogDevices
+    # @private
+    #
+    # A log device that writes to multiple IO devices.
+    #
+    # Note, you should not have to instantiate this class directly. Simply pass multiple
+    # arguments to the `Timber::Logger#new` method.
+    #
+    # See the {Timber::Logger#new} for examples.
+    class Multi
+      def initialize(targets)
+        @targets = targets
+      end
+
+      def write(*args)
+        @targets.each { |t| t.write(*args) }
+        @targets.first
+      end
+
+      def sync=(value)
+        @targets.each do |t|
+          if t.respond_to?(:sync=)
+            t.sync = value
+          end
+        end
+      end
+
+      def close
+        @targets.each(&:close)
+      end
+    end
+  end
+end

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -20,6 +20,15 @@ describe Timber::Logger, :rails_23 => true do
         expect(logger.formatter).to be_kind_of(Timber::Logger::MessageOnlyFormatter)
       end
     end
+
+    it "should use the Multi log device" do
+      io1 = StringIO.new
+      io2 = StringIO.new
+      logger = Timber::Logger.new(STDOUT, io1, io2)
+      logger.info("hello world")
+      expect(io1.string).to start_with("hello world @metadata {")
+      expect(io2.string).to start_with("hello world @metadata {")
+    end
   end
 
   describe "#add" do


### PR DESCRIPTION
This PR allows passing multiple IO devices to `Timber::Logger#new`.