### PR TITLE
Add deprecated Exception event class

### DIFF
--- a/lib/timber/events/exception.rb
+++ b/lib/timber/events/exception.rb
@@ -1,0 +1,9 @@
+require "timber/events/error"
+
+module Timber
+  module Events
+    # DEPRECATION: This class is deprecated in favor of using {Timber:Events:Error}.
+    class Exception < Error
+    end
+  end
+end


### PR DESCRIPTION
This adds `Timber::Events::Exception` as a deprecated class. This class has been renamed to `Timber::Events::Error` for simplicity across platforms. This allows all error and exception events to be represented as a single event. For example, Heroku platform errors are mapped as errors, as well as internal Ruby exceptions.