### PR TITLE
Remove framework_type in installer

### DIFF
--- a/lib/timber/cli/api/application.rb
+++ b/lib/timber/cli/api/application.rb
@@ -6,13 +6,12 @@ module Timber
         TEST_ENVIRONMENT = "test".freeze
         HEROKU = "heroku".freeze
 
-        attr_accessor :api_key, :environment, :framework_type, :heroku_drain_url,
+        attr_accessor :api_key, :environment, :heroku_drain_url,
           :name, :platform_type
 
         def initialize(attributes)
           @api_key = attributes.fetch("api_key")
           @environment = attributes.fetch("environment")
-          @framework_type = attributes.fetch("framework_type")
           @heroku_drain_url = attributes.fetch("heroku_drain_url")
           @name = attributes.fetch("name")
           @platform_type = attributes.fetch("platform_type")

--- a/lib/timber/cli/io/messages.rb
+++ b/lib/timber/cli/io/messages.rb
@@ -23,7 +23,6 @@ module Timber
 Woot! Your API 🔑  is valid:
 
 Name:      #{app.name} (#{app.environment})
-Framework: #{app.framework_type}
 Platform:  #{app.platform_type}
 MESSAGE
           message.rstrip

--- a/spec/timber/cli/installers/config_file_spec.rb
+++ b/spec/timber/cli/installers/config_file_spec.rb
@@ -6,7 +6,6 @@ describe Timber::CLI::Installers::ConfigFile, :rails_23 => true do
     attributes = {
       "api_key" => api_key,
       "environment" => "development",
-      "framework_type" => "rails",
       "heroku_drain_url" => "http://drain.heroku.com",
       "name" => "My Rails App",
       "platform_type" => "other"

--- a/spec/timber/cli/installers/other_spec.rb
+++ b/spec/timber/cli/installers/other_spec.rb
@@ -8,7 +8,6 @@ describe Timber::CLI::Installers::Other, :rails_23 => true do
     attributes = {
       "api_key" => api_key,
       "environment" => "development",
-      "framework_type" => "rails",
       "heroku_drain_url" => "http://drain.heroku.com",
       "name" => "My Rails App",
       "platform_type" => "other"

--- a/spec/timber/cli/installers/rails_spec.rb
+++ b/spec/timber/cli/installers/rails_spec.rb
@@ -6,7 +6,6 @@ describe Timber::CLI::Installers::Rails, :rails_23 => true do
     attributes = {
       "api_key" => api_key,
       "environment" => "development",
-      "framework_type" => "rails",
       "heroku_drain_url" => "http://drain.heroku.com",
       "name" => "My Rails App",
       "platform_type" => "other"

--- a/spec/timber/cli/installers/root_spec.rb
+++ b/spec/timber/cli/installers/root_spec.rb
@@ -8,7 +8,6 @@ describe Timber::CLI::Installers::Root, :rails_23 => true do
     attributes = {
       "api_key" => api_key,
       "environment" => "development",
-      "framework_type" => "rails",
       "heroku_drain_url" => "http://drain.heroku.com",
       "name" => "My Rails App",
       "platform_type" => "other"


### PR DESCRIPTION
Removing this field since it no longer exists in the API.