### PR TITLE
Improve installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_script:
 - echo $BUNDLE_GEMFILE
 - bundle install
 script:
-  - bundle exec bundle-audit update && bundle exec bundle-audit check
   - bundle exec rspec --format documentation
 matrix:
   fast_finish: true

--- a/lib/timber/cli/config_file.rb
+++ b/lib/timber/cli/config_file.rb
@@ -23,7 +23,7 @@ module Timber
       end
 
       def silence_template_renders!
-        append!("config.integrations.action_view.silence = true")
+        append!("config.integrations.action_view.silence = Rails.env.production?")
       end
 
       private

--- a/lib/timber/cli/file_helper.rb
+++ b/lib/timber/cli/file_helper.rb
@@ -33,8 +33,6 @@ module Timber
         File.open(path, "w") do |f|
           f.write(contents)
         end
-
-        api.event(:file_written, path: path)
       end
 
       def verify(path, io)

--- a/lib/timber/cli/installers/config_file.rb
+++ b/lib/timber/cli/installers/config_file.rb
@@ -15,77 +15,28 @@ module Timber
           config_file = Timber::CLI::ConfigFile.new(path, file_helper)
 
           if config_file.exists?
-            io.puts ""
             io.task_complete("#{config_file.path} already created")
             return true
           end
 
-          if logrageify?
-            config_file.logrageify!
-          elsif silence_template_renders?
-            config_file.silence_template_renders!
+          if lograge?
+            task_message = "Enabling logrageify in #{config_file.path}"
+            io.task(task_message) { config_file.logrageify! }
+          elsif action_view?
+            task_message = "Silencing template renders in #{config_file.path}"
+            io.task(task_message) { config_file.silence_template_renders! }
           end
 
-          io.puts ""
           task_message = "Creating #{config_file.path}"
           io.task(task_message) { config_file.create! }
         end
 
         private
-          def logrageify?
-            if lograge?
-              io.puts ""
-              io.puts IO::Messages.separator
-              io.puts ""
-              io.puts "We noticed you have lograge installed. Would you like to configure "
-              io.puts "Timber to function similarly?"
-              io.puts "(This silences template renders, sql queries, and controller calls."
-              io.puts "You can always do this later in config/initialzers/timber.rb)"
-              io.puts ""
-              io.puts "y) Yes, configure Timber like lograge", :blue
-              io.puts "n) No, use the Rails logging defaults", :blue
-              io.puts ""
-
-              case io.ask_yes_no("Enter your choice:", event_prompt: "Logrageify?")
-              when :yes
-                true
-              when :no
-                false
-              end
-            else
-              false
-            end
-          end
-
           def lograge?
             require "lograge"
             true
           rescue Exception
             false
-          end
-
-          def silence_template_renders?
-            if action_view?
-              io.puts ""
-              io.puts IO::Messages.separator
-              io.puts ""
-              io.puts "Would you like to silence template render logs?"
-              io.puts "(We've founds this to be of low value in production environments."
-              io.puts "You can always adjust this later in config/initialzers/timber.rb)"
-              io.puts ""
-              io.puts "y) Yes, silence template renders", :blue
-              io.puts "n) No, use the Rails logging defaults", :blue
-              io.puts ""
-
-              case io.ask_yes_no("Enter your choice:", event_prompt: "Silence template renders?")
-              when :yes
-                true
-              when :no
-                false
-              end
-            else
-              false
-            end
           end
 
           def action_view?

--- a/lib/timber/cli/installers/rails.rb
+++ b/lib/timber/cli/installers/rails.rb
@@ -41,7 +41,13 @@ module Timber
               io.puts "n) No, just print development logs to STDOUT", :blue
               io.puts ""
 
-              case io.ask_yes_no("Enter your choice:", event_prompt: "Send dev logs to Timber?")
+              input = io.ask_yes_no("Enter your choice:", event_prompt: "Send dev logs to Timber?")
+
+              io.puts ""
+              io.puts IO::Messages.separator
+              io.puts ""
+
+              case input
               when :yes
                 :send
               when :no
@@ -54,7 +60,7 @@ module Timber
             environment_file_path = get_environment_file_path("development")
             if environment_file_path
               if already_installed?(environment_file_path)
-                io.task_complete("Timber::Logger already installed #{environment_file_path}")
+                io.task_complete("Timber already installed #{environment_file_path}")
                 return :already_installed
               end
 
@@ -66,7 +72,9 @@ module Timber
 
                 logger_code = <<-CODE
   # Install the Timber.io logger
-  send_logs_to_timber = true # <---- set to false to stop sending dev logs to Timber.io
+  send_logs_to_timber = true # <---- Set to false to stop sending development logs to Timber.io.
+                             #       But do not remove the logger code below! The log_device should
+                             #       be set to STDOUT if you want to disable sending logs.
 
   log_device = send_logs_to_timber ? Timber::LogDevices::HTTP.new(#{api_key_code}) : STDOUT
   logger = Timber::Logger.new(log_device)
@@ -88,7 +96,7 @@ CODE
             environment_file_path = get_environment_file_path("test")
             if environment_file_path
               if already_installed?(environment_file_path)
-                io.task_complete("Timber::Logger already installed #{environment_file_path}")
+                io.task_complete("Timber already installed #{environment_file_path}")
                 return :already_installed
               end
 
@@ -102,7 +110,7 @@ CODE
             environment_file_path = get_environment_file_path(app.environment) || get_environment_file_path("production")
             if environment_file_path
               if already_installed?(environment_file_path)
-                io.task_complete("Timber::Logger already installed #{environment_file_path}")
+                io.task_complete("Timber already installed #{environment_file_path}")
                 return :already_installed
               end
 

--- a/lib/timber/cli/installers/root.rb
+++ b/lib/timber/cli/installers/root.rb
@@ -27,41 +27,16 @@ module Timber
           io.puts IO::Messages.application_details(app)
           io.puts ""
 
-          case io.ask_yes_no("Are the above details correct?", event_prompt: "App details correct?")
-          when :yes
-            install_platform(app)
-            run_sub_installer(app)
-            send_test_messages
-            confirm_log_delivery
-            wrap_up(app)
-            api.event(:success)
-            collect_feedback
-            free_data
-
-          when :no
-            io.puts ""
-            io.puts "Bummer. Head to this URL to update the details:"
-            io.puts ""
-            io.puts "    #{IO::Messages.edit_app_url(app)}", :blue
-            io.puts ""
-            io.puts "exiting..."
-          end
+          run_sub_installer(app)
+          send_test_messages
+          confirm_log_delivery
+          api.event(:success)
+          collect_feedback
+          free_data
+          wrap_up(app)
         end
 
         private
-          def install_platform(app)
-            if app.heroku?
-              io.puts ""
-              io.puts IO::Messages.separator
-              io.puts ""
-              io.puts IO::Messages.heroku_install(app)
-              io.puts ""
-              io.ask_to_proceed
-            end
-
-            true
-          end
-
           def run_sub_installer(app)
             sub_installer = get_sub_installer
             sub_installer.run(app)
@@ -100,67 +75,12 @@ module Timber
           end
 
           def wrap_up(app)
-            if app.development? || app.test?
-              development_note
-            else
-              assist_with_commit_and_deploy
-            end
-          end
-
-          def development_note
             io.puts ""
             io.puts IO::Messages.separator
             io.puts ""
-            io.puts "All done! To start using Timber:"
+            io.puts IO::ANSI.colorize("All done! Commit and deploy 🚀  to see logs in Timber.", :yellow)
+            io.puts IO::ANSI.colorize("You can also test drive Timber by starting your app locally.", :yellow)
             io.puts ""
-            io.puts IO::ANSI.colorize("1. Run your application locally to see logs show up in Timber", :blue)
-            io.puts IO::ANSI.colorize("2. When you're ready to move to production/staging, create a", :blue)
-            io.puts IO::ANSI.colorize("   production/staging app in Timber and follow the instructions shown.", :blue)
-            io.puts ""
-            io.ask_to_proceed
-          end
-
-          def assist_with_commit_and_deploy
-            io.puts ""
-            io.puts IO::Messages.separator
-            io.puts ""
-
-            if OSHelper.has_git?
-              case io.ask_yes_no("All done! Would you like to commit these changes?", event_prompt: "Run git commands?")
-              when :yes
-                io.puts ""
-
-                task_message = "Committing changes via git"
-                io.task_start(task_message)
-
-                committed = OSHelper.git_commit_changes
-
-                if committed
-                  io.task_complete(task_message)
-                else
-                  io.task_failed(task_message)
-
-                  io.puts ""
-                  io.puts "Bummer, it looks like we couldn't access the git command.", :yellow
-                  io.puts "No problem though, just run these commands yourself:", :yellow
-                  io.puts ""
-                  io.puts IO::Messages.git_commands
-                end
-              when :no
-                io.puts ""
-                io.puts "No problem. Here's the commands for reference when you're ready:"
-                io.puts ""
-                io.puts IO::Messages.git_commands
-              end
-            else
-              io.puts ""
-              io.puts "All done! Commit your changes:"
-              io.puts ""
-              io.puts IO::Messages.git_commands
-            end
-
-            io.puts ""
-            io.puts "=> Reminder: remember to deploy 🚀 to see logs in staging/production", :yellow
           end
 
           def collect_feedback
@@ -168,7 +88,7 @@ module Timber
             io.puts IO::Messages.separator
             io.puts ""
 
-            rating = io.ask("How would rate this install experience? 1 (bad) - 5 (perfect)", ["1", "2", "3", "4", "5"])
+            rating = io.ask("How would rate this install experience? 1 (bad) - 5 (perfect) or 'skip':", ["1", "2", "3", "4", "5", "skip"])
 
             case rating
             when "4", "5"
@@ -197,7 +117,6 @@ module Timber
             io.puts IO::Messages.separator
             io.puts ""
             io.puts IO::Messages.free_data
-            io.puts ""
           end
       end
     end

--- a/lib/timber/cli/io.rb
+++ b/lib/timber/cli/io.rb
@@ -17,17 +17,8 @@ module Timber
 
       def ask(prompt, allowed_inputs, options = {}, iteration = 0)
         event_prompt = options[:event_prompt] || prompt
-
-        if api
-          api.event(:waiting_for_input, prompt: event_prompt)
-        end
-
         write prompt + " "
         input = gets.downcase
-
-        if api
-          api.event(:received_input, prompt: event_prompt, value: input)
-        end
 
         if allowed_inputs.include?(input)
           input

--- a/lib/timber/cli/io/messages.rb
+++ b/lib/timber/cli/io/messages.rb
@@ -20,10 +20,7 @@ module Timber
 
         def application_details(app)
           message = <<-MESSAGE
-Woot! Your API 🔑  is valid:
-
-Name:      #{app.name} (#{app.environment})
-Platform:  #{app.platform_type}
+Woot! Your API 🔑  is valid: #{app.name} (#{app.environment}) on #{app.platform_type}
 MESSAGE
           message.rstrip
         end
@@ -101,7 +98,7 @@ MESSAGE
 
         def header
           message = <<-MESSAGE
-🌲 Timber.io Ruby Installer - Sane logging for Ruby developers.
+🌲 Timber.io Ruby Installer - Great Ruby Logging Made *Easy*
 
  ^  ^  ^   ^      ___I_      ^  ^   ^  ^  ^   ^  ^
 /|\\/|\\/|\\ /|\\    /\\-_--\\    /|\\/|\\ /|\\/|\\/|\\ /|\\/|\\

--- a/spec/timber/cli/installers/config_file_spec.rb
+++ b/spec/timber/cli/installers/config_file_spec.rb
@@ -26,25 +26,11 @@ describe Timber::CLI::Installers::ConfigFile, :rails_23 => true do
 
       expect(Timber::CLI::ConfigFile).to receive(:new).with(path, installer.file_helper).and_return(config_file)
       expect(config_file).to receive(:exists?).exactly(1).times.and_return(false)
-      expect(installer).to receive(:logrageify?).exactly(1).times.and_return(true)
+      expect(installer).to receive(:lograge?).exactly(1).times.and_return(true)
       expect(config_file).to receive(:logrageify!).exactly(1).times
       expect(config_file).to receive(:create!).exactly(1).times
 
       installer.run(app, path)
-    end
-  end
-
-  describe ".logrageify?" do
-    it "should do nothing if Lograge is not detected" do
-      expect(installer.send(:logrageify?)).to eq(false)
-      expect(output.string).to eq("")
-    end
-
-    it "should prompt for Lograge configuration and return true for y" do
-      allow(installer).to receive(:lograge?).and_return(true)
-      input.string = "y\n"
-      expect(installer.send(:logrageify?)).to eq(true)
-      expect(output.string).to eq("\n--------------------------------------------------------------------------------\n\nWe noticed you have lograge installed. Would you like to configure \nTimber to function similarly?\n(This silences template renders, sql queries, and controller calls.\nYou can always do this later in config/initialzers/timber.rb)\n\n\e[34my) Yes, configure Timber like lograge\e[0m\n\e[34mn) No, use the Rails logging defaults\e[0m\n\nEnter your choice: (y/n) ")
     end
   end
 end

--- a/spec/timber/cli/installers/rails_spec.rb
+++ b/spec/timber/cli/installers/rails_spec.rb
@@ -95,7 +95,9 @@ describe Timber::CLI::Installers::Rails, :rails_23 => true do
 
             expected_code = <<-CODE
   # Install the Timber.io logger
-  send_logs_to_timber = true # <---- set to false to stop sending dev logs to Timber.io
+  send_logs_to_timber = true # <---- Set to false to stop sending development logs to Timber.io.
+                             #       But do not remove the logger code below! The log_device should
+                             #       be set to STDOUT if you want to disable sending logs.
 
   log_device = send_logs_to_timber ? Timber::LogDevices::HTTP.new('#{app.api_key}') : STDOUT
   logger = Timber::Logger.new(log_device)

--- a/spec/timber/cli/installers/root_spec.rb
+++ b/spec/timber/cli/installers/root_spec.rb
@@ -24,7 +24,6 @@ describe Timber::CLI::Installers::Root, :rails_23 => true do
     it "should run properly" do
       input.string = "y\n"
 
-      expect(installer).to receive(:install_platform).with(app).exactly(1).times
       expect(installer).to receive(:run_sub_installer).with(app).exactly(1).times
       expect(installer).to receive(:send_test_messages).exactly(1).times
       expect(installer).to receive(:confirm_log_delivery).exactly(1).times
@@ -34,31 +33,6 @@ describe Timber::CLI::Installers::Root, :rails_23 => true do
       expect(installer).to receive(:free_data).exactly(1).times
 
       installer.run(app)
-    end
-  end
-
-  describe ".install_platform" do
-    context "non-heroku" do
-      it "should do nothing" do
-        expect(installer.send(:install_platform, app)).to eq(true)
-        expect(output.string).to eq("")
-      end
-    end
-
-    context "heroku" do
-      before(:each) do
-        app.platform_type = "heroku"
-      end
-
-      it "should prompt for Heroku install" do
-        input.string = "y\n"
-
-        expect(installer.send(:install_platform, app)).to eq(true)
-
-        copy_to_clipboard_message = Timber::CLI::OSHelper.can_copy_to_clipboard? ? "\n    \e[32m(✓ copied to clipboard)\e[0m" : ""
-        expected_output = "\n--------------------------------------------------------------------------------\n\nFirst, let's setup your Heroku drain. Run this command in a separate window:\n\n    \e[34mheroku drains:add http://drain.heroku.com\e[0m#{copy_to_clipboard_message}\n\nReady to proceed? (y/n) "
-        expect(output.string).to eq(expected_output)
-      end
     end
   end
 


### PR DESCRIPTION
This improves the installer by:

1. Removing the prompt asking them if the app details are correct.
2. Assume they want to silence template rendering in production. This makes for a better overall timber experience. These logs are designed for development.
3. Assume they want to enable the logrageify option if they already have lograge installed.
4. Remove the git commands. This is too assuming and can be destructive, especially if git hooks are installed.
5. Moves the "commit and deploy" message to be last since this is what you immediately read when the installer finishes.
6. Remove the Heroku / platform installation step since this is handled inside the timber app.