### PR TITLE
Require time to ensure the iso8601 method is available

### DIFF
--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -1,4 +1,5 @@
-require 'socket'
+require "socket"
+require "time"
 
 require "timber/contexts"
 require "timber/events"


### PR DESCRIPTION
On Windows this method is not present without a require of the `time` library.