### PR TITLE
Resolve capturing system and runtime context

### DIFF
--- a/lib/timber/current_context.rb
+++ b/lib/timber/current_context.rb
@@ -149,7 +149,7 @@ module Timber
 
         # Runtime context
         thread_object_id = Thread.current.object_id
-        runtime_context = Contexts::System.new(vm_pid: thread_object_id)
+        runtime_context = Contexts::Runtime.new(vm_pid: thread_object_id)
         add_to!(new_hash, runtime_context)
 
         new_hash

--- a/spec/timber/current_context_spec.rb
+++ b/spec/timber/current_context_spec.rb
@@ -7,6 +7,18 @@ describe Timber::CurrentContext, :rails_23 => true do
       expect(context.send(:hash)[:release]).to be_nil
     end
 
+    it "should set the system context" do
+      context = described_class.send(:new)
+      system_content = context.fetch(:system)
+      expect(system_content[:hostname]).to be_present
+    end
+
+    it "should set the runtime context" do
+      context = described_class.send(:new)
+      runtime_context = context.fetch(:runtime)
+      expect(runtime_context[:vm_pid]).to be_present
+    end
+
     context "with Heroku dyno metadata" do
       around(:each) do |example|
         ENV['HEROKU_SLUG_COMMIT'] = "2c3a0b24069af49b3de35b8e8c26765c1dba9ff0"


### PR DESCRIPTION
The `runtime` context was erroneously using the `Contexts::System` for initialization. This was overriding the `system` context with a blank map. This change uses the correct class and adds tests for capturing these contexts properly.