### PR TITLE
Coerce vm_pid into a String

### DIFF
--- a/lib/timber/contexts/custom.rb
+++ b/lib/timber/contexts/custom.rb
@@ -24,13 +24,13 @@ module Timber
       attr_reader :type, :data
 
       def initialize(attributes)
-        @type = attributes[:type] || raise(ArgumentError.new(":type is required"))
+        @type = Timber::Util::Object.try(attributes[:type], :to_sym) || raise(ArgumentError.new(":type is required"))
         @data = attributes[:data] || raise(ArgumentError.new(":data is required"))
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(options = {})
-        {Timber::Util::Object.try(type, :to_sym) => data}
+        {type => data}
       end
     end
   end

--- a/lib/timber/contexts/organization.rb
+++ b/lib/timber/contexts/organization.rb
@@ -24,13 +24,13 @@ module Timber
       attr_reader :id, :name
 
       def initialize(attributes)
-        @id = attributes[:id]
+        @id = Timber::Util::Object.try(attributes[:id], :to_s)
         @name = attributes[:name]
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {id: Timber::Util::Object.try(id, :to_s), name: name}
+        {id: id, name: name}
       end
     end
   end

--- a/lib/timber/contexts/runtime.rb
+++ b/lib/timber/contexts/runtime.rb
@@ -18,7 +18,7 @@ module Timber
         @function = attributes[:function]
         @line = attributes[:line]
         @module_name = attributes[:module_name]
-        @vm_pid = attributes[:vm_pid]
+        @vm_pid = Timber::Util::Object.try(attributes[:vm_pid], :to_s)
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).

--- a/lib/timber/contexts/session.rb
+++ b/lib/timber/contexts/session.rb
@@ -16,12 +16,12 @@ module Timber
       attr_reader :id
 
       def initialize(attributes)
-        @id = attributes[:id] || raise(ArgumentError.new(":id is required"))
+        @id = Timber::Util::Object.try(attributes[:id], :to_s) || raise(ArgumentError.new(":id is required"))
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {id: Timber::Util::Object.try(id, :to_s)}
+        {id: id}
       end
     end
   end

--- a/lib/timber/contexts/system.rb
+++ b/lib/timber/contexts/system.rb
@@ -14,13 +14,12 @@ module Timber
 
       def initialize(attributes)
         @hostname = attributes[:hostname]
-        @pid = attributes[:pid]
-        @pid = Timber::Util::Object.try(@pid, :to_i)
+        @pid = Timber::Util::Object.try(attributes[:pid], :to_i)
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {hostname: hostname, pid: Timber::Util::Object.try(pid, :to_i)}
+        {hostname: hostname, pid: pid}
       end
     end
   end

--- a/lib/timber/contexts/user.rb
+++ b/lib/timber/contexts/user.rb
@@ -16,7 +16,7 @@ module Timber
       attr_reader :id, :name, :email, :type, :meta
 
       def initialize(attributes)
-        @id = attributes[:id]
+        @id = Timber::Util::Object.try(attributes[:id], :to_s)
         @name = attributes[:name]
         @email = attributes[:email]
         @type = attributes[:type]
@@ -25,7 +25,7 @@ module Timber
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {id: Timber::Util::Object.try(id, :to_s), name: name, email: email, type: type, meta: meta}
+        {id: id, name: name, email: email, type: type, meta: meta}
       end
     end
   end

--- a/spec/timber/contexts/system_spec.rb
+++ b/spec/timber/contexts/system_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 describe Timber::Contexts::System, :rails_23 => true do
   describe ".as_json" do
-    it "should coerce pid into an string" do
+    it "should coerce pid into an integer" do
       custom_context = described_class.new(:pid => "1")
       json = custom_context.as_json()
       expect(json[:pid]).to eq(1)


### PR DESCRIPTION
This coerces the `context.runtime.vm_pid` field into a string, which is defined by our log event JSON schema. Currently this is being set as an integer. We cannot assume this is an integer since other languages and systems use strings.