### PR TITLE
Check for Devise using constant

### DIFF
--- a/lib/timber/frameworks/rails.rb
+++ b/lib/timber/frameworks/rails.rb
@@ -11,13 +11,7 @@ module Timber
           Timber::Config.instance.logger = Proc.new { ::Rails.logger }
         end
 
-        after =
-          begin
-            require 'devise'
-            'devise.omniauth'
-          rescue LoadError
-            :load_config_initializers
-          end
+        after = defined?(Devise) ? 'devise.omniauth' : :load_config_initializers
 
         # Must be loaded after initializers so that we respect any Timber configuration
         # set


### PR DESCRIPTION
Hey @binarylogic , the latest release `2.2.1` didn't fix my issue, but this seems to do the trick.

What seems to be happening is that Devise is the gem `requires 'devise'` I believe to check if it's part of your gemset so that the timber middleware is initialized after the `devise.omniauth` initializer. This seems to set up the omniauth middleware.

Then we have our own Omniauth code that makes another call to `config.omniauth` which [according to Devise](https://github.com/plataformatec/devise/wiki/OmniAuth:-Overview#before-you-start) sets the omniauth middleware up again and then breaks all authentication.

So, I think checking for the constant `Devise` would fulfill the same role as requiring the library, without reloading the omniauth initializer.

That being said, I'm not sure of the full consequences of this change, so figured I'd have you take a look 😄 