### PR TITLE
Update installer method to be platform aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Update the installer to be platform aware, recommending the appropriate delivery method
+    for the application's platform.
+
+
 ## [2.2.2] - 2017-09-14
+
 ### Fixed
 
   - Remove Railtie ordering clause based on devise omniauth initializer. This is no longer
     necessary since we do not integrate with Omniauth anymore.
 
 ## [2.2.1] - 2017-09-13
+
 ### Changed
 
   - Omniauth integration was removed since it only captures user context during the Authentication
@@ -21,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     and could cause unintended issues.
 
 ## [2.2.0] - 2017-09-13
+
 ### Changed
 
   - The default HTTP log device queue type was switched to a

--- a/lib/timber/cli/installer.rb
+++ b/lib/timber/cli/installer.rb
@@ -4,6 +4,8 @@ require "timber/cli/io/messages"
 module Timber
   class CLI
     class Installer
+      DEPRIORITIZED_PLATFORMS = ["linux", "other"].freeze
+
       attr_reader :io, :api, :file_helper
 
       def initialize(io, api)
@@ -18,10 +20,10 @@ module Timber
 
       private
         def get_delivery_strategy(app)
-          if app.heroku?
-            :stdout
-          else
+          if DEPRIORITIZED_PLATFORMS.include?(app.platform_type)
             :http
+          else
+            :stdout
           end
         end
 

--- a/lib/timber/cli/installers/other.rb
+++ b/lib/timber/cli/installers/other.rb
@@ -6,12 +6,13 @@ module Timber
     module Installers
       class Other < Installer
         def run(app)
-          if app.heroku?
-            install_stdout
-          else
+          case get_delivery_strategy(app)
+          when :http
             api_key_storage_preference = get_api_key_storage_preference
             api_key_code = get_api_key_code(api_key_storage_preference)
             install_http(api_key_code)
+          when :stdout
+            install_stdout
           end
 
           ask_to_proceed


### PR DESCRIPTION
Original versions of the installer checked for Heroku directly. This updates the installer to be aware of our multiple platforms, choosing the appropriate delivery method.