### PR TITLE
Allowing logging to multiple loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+  - Added the ability to pass additional loggers when instantiating a `::Timber::Logger`.
+
 ## [2.2.3] - 2017-09-18
 
 ### Fixed

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -21,13 +21,25 @@ describe Timber::Logger, :rails_23 => true do
       end
     end
 
-    it "should allow multiple loggers" do
+    it "should allow multiple io devices" do
       io1 = StringIO.new
       io2 = StringIO.new
       logger = Timber::Logger.new(STDOUT, io1, io2)
       logger.info("hello world")
       expect(io1.string).to start_with("hello world @metadata {")
       expect(io2.string).to start_with("hello world @metadata {")
+    end
+
+    it "should allow multiple io devices and loggers" do
+      io1 = StringIO.new
+      io2 = StringIO.new
+      io3 = StringIO.new
+      extra_logger = ::Logger.new(io3)
+      logger = Timber::Logger.new(STDOUT, io1, io2, extra_logger)
+      logger.info("hello world")
+      expect(io1.string).to start_with("hello world @metadata {")
+      expect(io2.string).to start_with("hello world @metadata {")
+      expect(io3.string).to end_with("hello world\n")
     end
   end
 


### PR DESCRIPTION
Allows logging to multiple loggers. Ex:

```ruby
http_device = Timber::LogDevices::HTTP.new("my-timber-api-key")
file_logger = ::Logger.new("path/to/file.log")
logger = Timber::Logger.new(http_device, file_logger)
```

Closes https://github.com/timberio/timber-ruby/issues/159