### PR TITLE
Forcibly fallback to SSLv23 if SSLv3 fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Forcibly fallback to SSLv23 if SSLv3 fails. SSLv3 is only used for outdated OpenSSL versions.
+
 ## [2.3.0] - 2017-09-26
 
 ### Added

--- a/lib/timber/cli/api.rb
+++ b/lib/timber/cli/api.rb
@@ -159,6 +159,11 @@ module Timber
           else
             res
           end
+        rescue OpenSSL::SSL::SSLError => e
+          if http.ssl_version != :SSLv23
+            http.ssl_version = :SSLv23
+            retry
+          end
         end
 
         def http


### PR DESCRIPTION
Older versions of OpenSSL will attempt to using SSLv3 which is not supported, this change forcibly falls back to SSLv23 is this is the case.

Closes https://github.com/timberio/timber-ruby/issues/161