### PR TITLE
Drop ASCII-8BIT (binary) strings before encoding log data to JSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ rvm:
 - 1.9.3
 - 2.2.6
 - 2.3.3
-- 2.4.1
-- jruby
+- 2.4.2
+- jruby-1.7.26
+- jruby-9.1.9.0
 gemfile:
 - gemfiles/rails-3.0.gemfile
 - gemfiles/rails-3.1.gemfile
 - gemfiles/rails-3.2.gemfile
 - gemfiles/rails-4.0.gemfile
 - gemfiles/rails-4.1.gemfile
-- gemfiles/rails-4.2.gemfile
 - gemfiles/rails-4.2.gemfile
 - gemfiles/rails-5.0.gemfile
 - gemfiles/rails-5.1.gemfile
@@ -38,15 +38,10 @@ matrix:
       gemfile: "gemfiles/rails-3.2.gemfile"
   allow_failures:
   - rvm: 1.9.3 # bundler wont install the gems
-  - rvm: 2.4.1
-  - rvm: jruby
-    gemfile: gemfiles/rails-3.0.gemfile
-  - rvm: jruby
-    gemfile: gemfiles/rails-5.0.gemfile
-  - rvm: jruby
-    gemfile: gemfiles/rails-5.1.gemfile
-  - rvm: jruby
-    gemfile: gemfiles/rails-edge.gemfile
+  - rvm: 2.4.2
+    gemfile: gemfiles/rails-4.0.gemfile
+  - rvm: 2.4.2
+    gemfile: gemfiles/rails-4.1.gemfile
 notifications:
   email: false
   slack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+  - Drop ASCII-8BIT (binary) data before encoding to JSON. This resolves encoding errors during
+    this process.
+
 ## [2.3.1] - 2017-09-26
 
 ### Fixed

--- a/lib/timber/util/hash.rb
+++ b/lib/timber/util/hash.rb
@@ -6,19 +6,20 @@ module Timber
 
       extend self
 
-      def deep_compact(hash)
+      # Deeply reduces a hash into a new hash, passing the current key, value,
+      # and accumulated map up to that point. This allows the caller to
+      # conditionally rebuild the hash.
+      def deep_reduce(hash, &block)
         new_hash = {}
 
         hash.each do |k, v|
           v = if v.is_a?(::Hash)
-            deep_compact(v)
+            deep_reduce(v, &block)
           else
             v
           end
 
-          if v != nil && (!v.respond_to?(:length) || v.length > 0)
-            new_hash[k] = v
-          end
+          block.call(k, v, new_hash)
         end
 
         new_hash

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ if !ENV["RAILS_23"]
   require File.join(File.dirname(__FILE__), 'support', 'active_record')
 end
 
+RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 5_000
+
 RSpec.configure do |config|
   config.color = true
   config.order = :random

--- a/spec/timber/log_entry_spec.rb
+++ b/spec/timber/log_entry_spec.rb
@@ -3,6 +3,45 @@ require "spec_helper"
 describe Timber::LogEntry, :rails_23 => true do
   let(:time) { Time.utc(2016, 9, 1, 12, 0, 0) }
 
+  describe "#as_json" do
+    it "should drop nil value keys" do
+      event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: nil})
+      log_entry = described_class.new("INFO", time, nil, "log message", {}, event)
+      hash = log_entry.as_json
+      expect(hash.key?(:event)).to be false
+    end
+
+    it "should drop blank string value keys" do
+      event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: ""})
+      log_entry = described_class.new("INFO", time, nil, "log message", {}, event)
+      hash = log_entry.as_json
+      expect(hash.key?(:event)).to be false
+    end
+
+    it "should drop empty array value keys" do
+      event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: []})
+      log_entry = described_class.new("INFO", time, nil, "log message", {}, event)
+      hash = log_entry.as_json
+      expect(hash.key?(:event)).to be false
+    end
+
+    it "should drop ascii-8bit (binary) value keys" do
+      binary = ("a" * 1001).force_encoding("ASCII-8BIT")
+      event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: binary})
+      log_entry = described_class.new("INFO", time, nil, "log message", {}, event)
+      hash = log_entry.as_json
+      expect(hash.key?(:event)).to be false
+    end
+
+    it "should keep ascii-8bit (binary) values below the threshold" do
+      binary = "test".force_encoding("ASCII-8BIT")
+      event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: binary})
+      log_entry = described_class.new("INFO", time, nil, "log message", {}, event)
+      hash = log_entry.as_json
+      expect(hash[:event][:custom][:event_type][:a].encoding).to eq(::Encoding::UTF_8)
+    end
+  end
+
   describe "#to_msgpack" do
     it "should encode properly with an event and context" do
       event = Timber::Events::Custom.new(type: :event_type, message: "event_message", data: {a: 1})


### PR DESCRIPTION
Fixes JSON encoding errors while attempting to encode binary data.

Closes https://github.com/timberio/timber-ruby/issues/163