### PR TITLE
get debug_to_file! to work

### DIFF
--- a/lib/timber/config.rb
+++ b/lib/timber/config.rb
@@ -77,12 +77,8 @@ module Timber
     # @example Everything else
     #   Timber::Config.instance.debug_to_file!("log/timber.log")
     def debug_to_file!(file_path)
-      unless File.exist? File.dirname path
-        FileUtils.mkdir_p File.dirname path
-      end
-      file = File.open file_path, "a"
-      file.binmode
-      file.sync = config.autoflush_log
+      FileUtils.mkdir_p( File.dirname(file_path) )
+      file = File.open(file_path, "ab")
       file_logger = ::Logger.new(file)
       file_logger.formatter = SimpleLogFormatter.new
       self.debug_logger = file_logger


### PR DESCRIPTION
`debug_to_file!()` didn't work as the docs said it did.

- `debug_to_file!` referenced a variable `path` that should have been `file_path`
- no need to check if the directory exists as `mkdir_p` only creates the path if it doesn't already exist.
- File.open(..., "ab") opens the file in binary mode
- removed `.sync = config.autoflush_log` as `autoflush_log` doesn't exist anywhere and the Logger.initializer already sets `sync` to `true` 