### PR TITLE
Raise params_json limit to match the new JSON schema limit of 32_768

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ matrix:
     gemfile: gemfiles/rails-4.0.gemfile
   - rvm: 2.4.2
     gemfile: gemfiles/rails-4.1.gemfile
+  - rvm: "jruby-1.7.26"
+  - rvm: "jruby-9.1.9.0"
 notifications:
   email: false
   slack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+  - Raises the limit on the `params_json` field for the `ControllerCallEvent` to `32768` bytes.
+
 ## [2.3.2] - 2017-09-27
 
 ### Fixed

--- a/lib/timber/cli/api.rb
+++ b/lib/timber/cli/api.rb
@@ -162,7 +162,7 @@ module Timber
         rescue OpenSSL::SSL::SSLError => e
           if http.ssl_version != :SSLv23
             http.ssl_version = :SSLv23
-            retry
+            issue!(req)
           end
         end
 

--- a/lib/timber/events/controller_call.rb
+++ b/lib/timber/events/controller_call.rb
@@ -10,7 +10,7 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionController::LogSubscriber} integration.
     class ControllerCall < Timber::Event
-      PARAMS_JSON_MAX_BYTES = 8192.freeze
+      PARAMS_JSON_MAX_BYTES = 32_768.freeze
       PASSWORD_NAME = 'password'.freeze
 
       attr_reader :controller, :action, :params, :format


### PR DESCRIPTION
Raises the `ControllerCall#params_json` limit to `32768` bytes to match this change: https://github.com/timberio/log-event-json-schema/pull/34