### PR TITLE
Add host to the HTTP context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+  - Adds the new `host` field into the `http` context, bumping the log event JSON schema to `3.2.0`.
+
 ## [2.3.4] - 2017-10-12
 
 ### Fixed

--- a/lib/timber/contexts/http.rb
+++ b/lib/timber/contexts/http.rb
@@ -15,18 +15,20 @@ module Timber
     class HTTP < Context
       @keyspace = :http
 
-      attr_reader :method, :path, :remote_addr, :request_id
+      attr_reader :host, :method, :path, :remote_addr, :request_id
 
       def initialize(attributes)
+        @host = attributes[:host]
         @method = attributes[:method] || raise(ArgumentError.new(":method is required"))
-        @path = attributes[:path] || raise(ArgumentError.new(":path is required"))
+        @path = attributes[:path]
         @remote_addr = attributes[:remote_addr]
         @request_id = attributes[:request_id]
       end
 
       # Builds a hash representation containing simple objects, suitable for serialization (JSON).
       def as_json(_options = {})
-        {:method => method, :path => path, :remote_addr => remote_addr, :request_id => request_id}
+        {:host => host, :method => method, :path => path, :remote_addr => remote_addr,
+          :request_id => request_id}
       end
     end
   end

--- a/lib/timber/integrations/rack/http_context.rb
+++ b/lib/timber/integrations/rack/http_context.rb
@@ -11,6 +11,7 @@ module Timber
         def call(env)
           request = Util::Request.new(env)
           context = Contexts::HTTP.new(
+            host: request.host,
             method: request.request_method,
             path: request.path,
             remote_addr: request.ip,

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -11,7 +11,7 @@ module Timber
     BINARY_LIMIT_THRESHOLD = 1_000.freeze
     DT_PRECISION = 6.freeze
     MESSAGE_MAX_BYTES = 8192.freeze
-    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.1.3/schema.json".freeze
+    SCHEMA = "https://raw.githubusercontent.com/timberio/log-event-json-schema/v3.2.0/schema.json".freeze
 
     attr_reader :context_snapshot, :event, :level, :message, :progname, :tags, :time, :time_ms
 

--- a/spec/timber/integrations/rack/http_context_spec.rb
+++ b/spec/timber/integrations/rack/http_context_spec.rb
@@ -42,12 +42,12 @@ if defined?(::Rack)
         dispatch_rails_request("/rack_http")
         http_context = Thread.current[:_timber_context_snapshot][:http]
 
-        expect(http_context).to eq({:method=>"GET", :path=>"/rack_http", :remote_addr=>"123.456.789.10", :request_id=>"unique-request-id-1234"})
+        expect(http_context).to eq({:host => "example.org", :method=>"GET", :path=>"/rack_http", :remote_addr=>"123.456.789.10", :request_id=>"unique-request-id-1234"})
 
         lines = clean_lines(io.string.split("\n"))
         expect(lines.length).to eq(3)
         lines.each do |line|
-          expect(line).to include("\"http\":{\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}")
+          expect(line).to include("\"http\":{\"host\":\"example.org\",\"method\":\"GET\",\"path\":\"/rack_http\",\"remote_addr\":\"123.456.789.10\",\"request_id\":\"unique-request-id-1234\"}")
         end
       end
     end


### PR DESCRIPTION
This updates the log event JSON schema to `v3.2.0` which supports the new `host` attribute in the `http` context. This is useful for apps that are spread across multiple domains, including sub-domains. Timber will be adding this field as a facet if it contains a cardinality > 1.