### PR TITLE
Remove social promotions 😢

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+  - Remove social promotions during the installation process
+
 ## [2.4.0] - 2017-10-23
 
 ### Added

--- a/lib/timber/cli/installers/root.rb
+++ b/lib/timber/cli/installers/root.rb
@@ -32,7 +32,6 @@ module Timber
           confirm_log_delivery
           api.event(:success)
           collect_feedback
-          free_data
           wrap_up(app)
         end
 
@@ -110,13 +109,6 @@ module Timber
               io.puts ""
               io.puts "Thank you! We take feedback seriously and will work to improve this."
             end
-          end
-
-          def free_data
-            io.puts ""
-            io.puts IO::Messages.separator
-            io.puts ""
-            io.puts IO::Messages.free_data
           end
       end
     end

--- a/lib/timber/cli/io/messages.rb
+++ b/lib/timber/cli/io/messages.rb
@@ -86,16 +86,6 @@ MESSAGE
           message
         end
 
-        def free_data
-          message = <<-MESSAGE
-Get free data:
-
-* Get ✨ 250mb✨  for starring our repo: #{IO::ANSI.colorize(REPO_URL, :blue)}
-* Get ✨ 250mb✨  for tweeting your experience to #{IO::ANSI.colorize(TWITTER_HANDLE, :blue)}
-MESSAGE
-          message.rstrip
-        end
-
         def header
           message = <<-MESSAGE
 🌲 Timber.io Ruby Installer - Great Ruby Logging Made *Easy*

--- a/spec/timber/cli/installers/root_spec.rb
+++ b/spec/timber/cli/installers/root_spec.rb
@@ -30,7 +30,6 @@ describe Timber::CLI::Installers::Root, :rails_23 => true do
       expect(installer).to receive(:wrap_up).with(app).exactly(1).times
       expect(api).to receive(:event).with(:success).exactly(1).times
       expect(installer).to receive(:collect_feedback).exactly(1).times
-      expect(installer).to receive(:free_data).exactly(1).times
 
       installer.run(app)
     end


### PR DESCRIPTION
This removes the free data social promotions during the installation process. Integrating this with our billing system and making it available in the interface has proven to be much more difficult than anticipated. Currently, all customers are receiving this promotion, but it is not indicated on the interface. Any customer that participated will continue to receive this promotion and it will be made available in the billing interface as soon as we have the capability to do so.