### PR TITLE
Add content_length to both http_request and http_response events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Adds an override for ActiveSupport::Buffered logger. This is a legacy class that was dropped
     in Rails >= 4. It lacked #formatter accessor methods, which was a bug that was never resolved.
 
+### Added
+
+  - Capture `content_length` for both HTTP request and HTTP response events. This field is
+    available in the log's metadata. The response event now includes the content length in the
+    actual log message. The request message remains unchanged.
+
 ## [2.4.0] - 2017-10-23
 
 ### Added

--- a/lib/timber/events/http_request.rb
+++ b/lib/timber/events/http_request.rb
@@ -9,11 +9,12 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionController::LogSubscriber} integration.
     class HTTPRequest < Timber::Event
-      attr_reader :body, :headers, :host, :method, :path, :port, :query_string, :request_id,
-        :scheme, :service_name
+      attr_reader :body, :content_length, :headers, :host, :method, :path, :port, :query_string,
+        :request_id, :scheme, :service_name
 
       def initialize(attributes)
         @body = attributes[:body] && Util::HTTPEvent.normalize_body(attributes[:body])
+        @content_length = attributes[:content_length]
         @headers = Util::HTTPEvent.normalize_headers(attributes[:headers])
         @host = attributes[:host]
         @method = Util::HTTPEvent.normalize_method(attributes[:method]) || raise(ArgumentError.new(":method is required"))
@@ -25,8 +26,9 @@ module Timber
       end
 
       def to_hash
-        {body: body, headers: headers, host: host, method: method, path: path, port: port,
-          query_string: query_string, request_id: request_id, scheme: scheme}
+        {body: body, content_length: content_length, headers: headers, host: host, method: method,
+          path: path, port: port, query_string: query_string, request_id: request_id,
+          scheme: scheme}
       end
       alias to_h to_hash
 

--- a/lib/timber/events/http_response.rb
+++ b/lib/timber/events/http_response.rb
@@ -9,10 +9,11 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionController::LogSubscriber} integration.
     class HTTPResponse < Timber::Event
-      attr_reader :body, :headers, :http_context, :request_id, :service_name, :status, :time_ms
+      attr_reader :body, :content_length, :headers, :http_context, :request_id, :service_name, :status, :time_ms
 
       def initialize(attributes)
         @body = attributes[:body] && Util::HTTPEvent.normalize_body(attributes[:body])
+        @content_length = attributes[:content_length]
         @headers = Util::HTTPEvent.normalize_headers(attributes[:headers])
         @http_context = attributes[:http_context]
         @request_id = attributes[:request_id]
@@ -22,7 +23,8 @@ module Timber
       end
 
       def to_hash
-        {body: body, headers: headers, request_id: request_id, status: status, time_ms: time_ms}
+        {body: body, content_length: content_length, headers: headers, request_id: request_id,
+          status: status, time_ms: time_ms}
       end
       alias to_h to_hash
 
@@ -34,10 +36,22 @@ module Timber
       # Returns the human readable log message for this event.
       def message
         if http_context
-          "#{http_context[:method]} #{http_context[:path]} sent #{status} #{status_description} " \
-            "in #{time_ms}ms"
+          message = "#{http_context[:method]} #{http_context[:path]} completed with " \
+            "#{status} #{status_description} "
+
+          if content_length
+            message += ", #{content_length} bytes, "
+          end
+
+          message + "in #{time_ms}ms"
         else
-          "Completed #{status} #{status_description} in #{time_ms}ms"
+          message = "Completed #{status} #{status_description} "
+
+          if content_length
+            message += ", #{content_length} bytes, "
+          end
+
+          message + "in #{time_ms}ms"
         end
       end
 

--- a/lib/timber/integrations/rack/http_events.rb
+++ b/lib/timber/integrations/rack/http_events.rb
@@ -126,9 +126,11 @@ module Timber
             Config.instance.logger.info do
               http_context_key = Contexts::HTTP.keyspace
               http_context = CurrentContext.fetch(http_context_key)
+              content_length = headers[::Rack::CONTENT_LENGTH]
               time_ms = (Time.now - start) * 1000.0
 
               Events::HTTPResponse.new(
+                content_length: content_length,
                 headers: headers,
                 http_context: http_context,
                 request_id: request.request_id,
@@ -147,6 +149,7 @@ module Timber
 
               Events::HTTPRequest.new(
                 body: event_body,
+                content_length: request.content_length,
                 headers: request.headers,
                 host: request.host,
                 method: request.request_method,
@@ -161,11 +164,13 @@ module Timber
             status, headers, body = @app.call(env)
 
             Config.instance.logger.info do
-              time_ms = (Time.now - start) * 1000.0
               event_body = capture_response_body? ? body : nil
+              content_length = headers[::Rack::CONTENT_LENGTH]
+              time_ms = (Time.now - start) * 1000.0
 
               Events::HTTPResponse.new(
                 body: event_body,
+                content_length: content_length,
                 headers: headers,
                 request_id: request.request_id,
                 status: status,

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -30,6 +30,7 @@ if defined?(::Rails)
         application = ::Rails.application
         env = application.respond_to?(:env_config) ? application.env_config.clone : application.env_defaults.clone
         env["rack.request.cookie_hash"] = {}.with_indifferent_access
+        env["CONTENT_LENGTH"] = 100
         env["REMOTE_ADDR"] = "123.456.789.10"
         env["HTTP_X_REQUEST_ID"] = "unique-request-id-1234"
         env["action_dispatch.request_id"] = env["HTTP_X_REQUEST_ID"]

--- a/spec/timber/integrations/rack/http_events_spec.rb
+++ b/spec/timber/integrations/rack/http_events_spec.rb
@@ -88,7 +88,7 @@ if defined?(::Rack)
           expect(lines.length).to eq(2)
 
           expect(lines[0]).to start_with("Processing by RackHttpController#index as HTML @metadata ")
-          expect(lines[1]).to start_with("GET /rack_http sent 200 OK in 0.0ms @metadata ")
+          expect(lines[1]).to start_with("GET /rack_http completed with 200 OK in 0.0ms @metadata ")
         end
       end
     end


### PR DESCRIPTION
Adds the `content_length` field to both `http_request` and `http_response` events.

Closes https://github.com/timberio/timber-ruby/issues/170