### PR TITLE
Add #formatter accessor methods to ActiveSupport::BufferedLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   - Remove social promotions during the installation process
 
+### Fixed
+
+  - Adds an override for ActiveSupport::Buffered logger. This is a legacy class that was dropped
+    in Rails >= 4. It lacked #formatter accessor methods, which was a bug that was never resolved.
+
 ## [2.4.0] - 2017-10-23
 
 ### Added

--- a/lib/timber/overrides.rb
+++ b/lib/timber/overrides.rb
@@ -1,6 +1,7 @@
 # The order is relevant
 require "timber/overrides/active_support_3_tagged_logging"
 require "timber/overrides/active_support_tagged_logging"
+require "timber/overrides/active_support_buffered_logger"
 require "timber/overrides/lograge"
 require "timber/overrides/rails_stdout_logging"
 

--- a/lib/timber/overrides/active_support_3_tagged_logging.rb
+++ b/lib/timber/overrides/active_support_3_tagged_logging.rb
@@ -1,3 +1,8 @@
+# Please note, this patch is merely an upgrade, backporting improved tagged logging code
+# from newer versions of Rails:
+# https://github.com/rails/rails/blob/5-1-stable/activesupport/lib/active_support/tagged_logging.rb
+# The behavior of tagged logging will not change in any way.
+#
 # This patch is specifically for Rails 3. The legacy approach to wrapping the logger in
 # ActiveSupport::TaggedLogging is rather poor, hence the reason it was changed entirely
 # for Rails 4 and 5. The problem is that ActiveSupport::TaggedLogging is a wrapping
@@ -79,9 +84,12 @@ begin
         end
 
         def self.new(logger)
-          # Ensure we set a default formatter so we aren't extending nil!
-          logger.formatter ||= SimpleFormatter.new
-          logger.formatter.extend Formatter
+          if logger.respond_to?(:formatter=) && logger.respond_to?(:formatter)
+            # Ensure we set a default formatter so we aren't extending nil!
+            logger.formatter ||= SimpleFormatter.new
+            logger.formatter.extend Formatter
+          end
+
           logger.extend(self)
         end
 

--- a/lib/timber/overrides/active_support_buffered_logger.rb
+++ b/lib/timber/overrides/active_support_buffered_logger.rb
@@ -1,0 +1,22 @@
+# This adds a #formatter and #formatter= method to the legacy ActiveSupport::BufferedLogger
+# class. This bug was never resolved due to it being phased out past Rails >= 4.
+
+begin
+  require "active_support/buffered_logger"
+
+  class ActiveSupport::BufferedLogger
+    def formatter
+      if @log.respond_to?(:formatter)
+        @log.formatter
+      end
+    end
+
+    def formatter=(value)
+      if @log.respond_to?(:formatter=)
+        @log.formatter = value
+      end
+    end
+  end
+
+rescue Exception
+end

--- a/spec/rails/tagged_logging_spec.rb
+++ b/spec/rails/tagged_logging_spec.rb
@@ -3,6 +3,20 @@ require "spec_helper"
 # ActiveSupport::TaggedLogging is not defined in <= 3.1
 if defined?(::ActiveSupport::TaggedLogging)
   describe ActiveSupport::TaggedLogging, :rails_23 => true do
+    describe "#new" do
+      let(:io) { StringIO.new }
+
+      it "should instantiate for Timber::Logger object" do
+        ActiveSupport::TaggedLogging.new(Timber::Logger.new(io))
+      end
+
+      if defined?(ActiveSupport::BufferedLogger)
+        it "should instantiate for a ActiveSupport::BufferedLogger object" do
+          ActiveSupport::TaggedLogging.new(ActiveSupport::BufferedLogger.new(io))
+        end
+      end
+    end
+
     describe "#info" do
       let(:time) { Time.utc(2016, 9, 1, 12, 0, 0) }
       let(:io) { StringIO.new }


### PR DESCRIPTION
This adds a #formatter and #formatter= method to the legacy ActiveSupport::BufferedLogger class. This bug was never resolved due to it being phased out past Rails >= 4.
