### PR TITLE
Improve ExceptionWrapper compatibility detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+  - Fixes `::ActionDispatch::ExceptionWrapper` version detection preventing the `undefined method clean for #<Hash:->` error when an exception is raised in a Rack request.
+
+## [2.6.0-beta1] - 2017-10-28
+
+### Fixed
+
   - Encoding and rewind issues for file upload parameters have been resolved. Timber
     improved attribute normalization across all contexts and events, ignoring binary
     values like this in general.
@@ -109,7 +115,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     instead of applying back pressure.
 
 
-[Unreleased]: https://github.com/timberio/timber-ruby/compare/v2.5.1...HEAD
+[Unreleased]: https://github.com/timberio/timber-ruby/compare/v2.6.0-beta1...HEAD
+[2.6.0-beta1]: https://github.com/timberio/timber-ruby/compare/v2.5.1...v2.6.0-beta1
 [2.5.1]: https://github.com/timberio/timber-ruby/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/timberio/timber-ruby/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/timberio/timber-ruby/compare/v2.3.4...v2.4.0

--- a/lib/timber/events/error.rb
+++ b/lib/timber/events/error.rb
@@ -16,7 +16,7 @@ module Timber
       def initialize(attributes)
         normalizer = Util::AttributeNormalizer.new(attributes)
         @name = normalizer.fetch!(:name, :string)
-        @error_message = normalizer.fetch!(:error_message, :string, :limit => MESSAGE_MAX_BYTES)
+        @error_message = normalizer.fetch(:error_message, :string, :limit => MESSAGE_MAX_BYTES)
         @backtrace = normalizer.fetch(:backtrace, :array)
       end
 
@@ -35,7 +35,13 @@ module Timber
       end
 
       def message
-        "#{name} (#{error_message})"
+        message = "#{name}"
+
+        if !error_message.nil?
+          message << " (#{error_message})"
+        end
+
+        message
       end
     end
   end

--- a/lib/timber/integrations/rack/error_event.rb
+++ b/lib/timber/integrations/rack/error_event.rb
@@ -18,11 +18,8 @@ module Timber
       # {Timber::Events::Error}.
       class ErrorEvent < Middleware
         # We determine this when the app loads to avoid the overhead on a per request basis.
-        EXCEPTION_WRAPPER_TAKES_CLEANER = if Gem.loaded_specs["rails"]
-          Gem.loaded_specs["rails"].version >= Gem::Version.new('5.0.0')
-        else
-          false
-        end
+        EXCEPTION_WRAPPER_TAKES_CLEANER = defined?(::ActionDispatch::ExceptionWrapper) &&
+          !::ActionDispatch::ExceptionWrapper.instance_methods.include?(:env)
 
         def call(env)
           begin

--- a/lib/timber/util/attribute_normalizer.rb
+++ b/lib/timber/util/attribute_normalizer.rb
@@ -14,7 +14,6 @@ module Timber
       def fetch!(key, type, options = {})
         v = fetch(key, type, options)
         if v.nil?
-          raise @attributes.inspect
           raise ArgumentError.new("The #{key.inspect} attribute is required")
         end
         v

--- a/lib/timber/version.rb
+++ b/lib/timber/version.rb
@@ -1,3 +1,3 @@
 module Timber
-  VERSION = "2.5.1"
+  VERSION = "2.6.0-beta1"
 end

--- a/spec/timber/integrations/rack/error_event_spec.rb
+++ b/spec/timber/integrations/rack/error_event_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+
+if defined?(::Rack)
+  describe Timber::Integrations::Rack::ErrorEvent do
+    let(:time) { Time.utc(2016, 9, 1, 12, 0, 0) }
+    let(:io) { StringIO.new }
+    let(:logger) do
+      logger = Timber::Logger.new(io)
+      logger.level = ::Logger::INFO
+      logger
+    end
+
+    around(:each) do |example|
+      class RackErrorController < ActionController::Base
+        layout nil
+
+        hook_name = respond_to?(:before_action) ? "before_action" : "before_filter"
+        send(hook_name) do
+          raise "Boom!"
+        end
+
+        def index
+          Thread.current[:_timber_context_snapshot] = Timber::CurrentContext.instance.snapshot
+          render json: {}
+        end
+
+        def method_for_action(action_name)
+          action_name
+        end
+      end
+
+      ::RailsApp.routes.draw do
+        get '/rack_error' => 'rack_error#index'
+      end
+
+      with_rails_logger(logger) do
+        Timecop.freeze(time) { example.run }
+      end
+
+      Object.send(:remove_const, :RackErrorController)
+    end
+
+    describe "#process" do
+      it "should log the exception" do
+        allow(Benchmark).to receive(:ms).and_return(1).and_yield
+
+        expect { dispatch_rails_request("/rack_error") }.to raise_error(RuntimeError)
+
+        lines = clean_lines(io.string.split("\n"))
+        expect(lines.length).to eq(3)
+
+        expect(lines[0]).to start_with("Started GET \"/rack_error\" @metadata ")
+        expect(lines[1]).to start_with("Processing by RackErrorController#index as HTML @metadata ")
+        expect(lines[2]).to start_with("RuntimeError (Boom!) @metadata")
+      end
+    end
+
+    # Remove blank lines since Rails does this to space out requests in the logs
+    def clean_lines(lines)
+      lines.select { |line| !line.start_with?(" @metadat") }
+    end
+  end
+end


### PR DESCRIPTION
This PR updates how we detect versions of the `::ActionDispatch::ExceptionWrapper` class. Previously we were determining this via:

```ruby
Gem.loaded_specs["rails"].version >= Gem::Version.new('5.0.0')
```

This has proved to be unreliable across environments. Instead, we're checking the actual class behaviour directly via `.instance_methods`. This resolves https://github.com/timberio/timber-ruby/issues/183 since this was causing Timber to pass the entire Rack env hash to this class.

Closes https://github.com/timberio/timber-ruby/issues/183