### PR TITLE
Fix blank custom context errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.6.0-beta1] - 2017-10-28
-
 ### Fixed
 
-  - Fixes `::ActionDispatch::ExceptionWrapper` version detection preventing the `undefined method clean for #<Hash:->` error when an exception is raised in a Rack request.
+  - Fixes an issue where a reference to the current custom context map was being capture during log line creation and then later self-modifying to make the context invalid.
 
 ## [2.6.0-beta1] - 2017-10-28
 
@@ -20,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Encoding and rewind issues for file upload parameters have been resolved. Timber
     improved attribute normalization across all contexts and events, ignoring binary
     values like this in general.
+  - Fixes `::ActionDispatch::ExceptionWrapper` version detection preventing the `undefined method clean for #<Hash:->` error when an exception is raised in a Rack request.
 
 ## [2.5.1] - 2017-10-27
 

--- a/lib/timber/current_context.rb
+++ b/lib/timber/current_context.rb
@@ -120,7 +120,13 @@ module Timber
     # since the context can change as execution proceeds. Note that individual contexts
     # should be immutable, and we implement snapshot caching as a result of this assumption.
     def snapshot
-      @snapshot ||= hash.clone
+      @snapshot ||= begin
+        snapshot = hash.clone
+        if snapshot.key?(:custom)
+          snapshot[:custom] = hash[:custom].clone
+        end
+        snapshot
+      end
     end
 
     private

--- a/lib/timber/log_devices/http.rb
+++ b/lib/timber/log_devices/http.rb
@@ -147,6 +147,7 @@ module Timber
           req['Authorization'] = authorization_payload
           req['Content-Type'] = CONTENT_TYPE
           req['User-Agent'] = USER_AGENT
+
           req.body = msgs.to_msgpack
           req
         end

--- a/spec/timber/current_context_spec.rb
+++ b/spec/timber/current_context_spec.rb
@@ -98,6 +98,18 @@ describe Timber::CurrentContext, :rails_23 => true do
     end
   end
 
+  describe ".snapshot" do
+    it "shoud properly snapshot custom contexts" do
+      snapshot = nil
+
+      described_class.with({build: {version: "1.0.0"}}) do
+        snapshot = described_class.instance.snapshot
+      end
+
+      expect(snapshot[:custom]).to eq({:build=>{:version=>"1.0.0"}})
+    end
+  end
+
   describe ".with" do
     it "should merge the context and cleanup on block exit" do
       expect(described_class.instance.send(:hash)[:custom]).to be_nil


### PR DESCRIPTION
This resolves a bug where the reference to the current custom context map was being passed to the backend log device while later being modified, thus making the log line invalid before being transmitted.