### PR TITLE
Add more info to the docs about adding custom contexts

### DIFF
--- a/lib/timber/current_context.rb
+++ b/lib/timber/current_context.rb
@@ -57,6 +57,13 @@ module Timber
     #     # ... anything logged here will include the context ...
     #   end
     #
+    # @note Any custom context needs to have a single root key to be valid. i.e. instead of:
+    #   Timber::CurrentContext.with(job_id: "123", job_name: "Refresh User Account")
+    #
+    # do
+    #
+    #   Timber::CurrentContext.with(job: {job_id: "123", job_name: "Refresh User Account"})
+    #
     # @example Adding multiple contexts
     #   Timber::CurrentContext.with(context1, context2) { ... }
     def with(*objects)


### PR DESCRIPTION
Suggesting this because I just wasted a bunch of time trying to add a custom context that was incorrectly formatted (tried with all the keys at the root and with multiple root keys).

Ideally there would be an informative error but I don't know if it's reasonable to have `Timber::Contexts.build` raise an error when the passed in `obj` either has two root keys or has one root key but the value is not a hash. Right now those fail with errors like:

    > Timber::CurrentContext.with({other: 42}, &block)
    NoMethodError:
      undefined method `each' for 42:Fixnum

    > Timber::CurrentContext.with({first_key: 1, second_key: 2}, &block)
    NoMethodError:
      undefined method `keyspace' for nil:NilClass

If it makes sense I could add code to detect those two cases and raise an informative `ArgumentError` in `Timber::Contexts.build`