### PR TITLE
Remove tagged logging parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+  - Rails tagged logging default behavior has been preserved. Previously Timber would strip
+    Rails logging tags and place them in the `tags` key. This is no longer the case and tags
+    will function just as they would without Timber by prefixing your messages with tags.
+    We strongly encourage disabling tags and using the available Timber API for logging structured
+    data (please see the examples in the README).
+
 ## [2.6.1] - 2017-11-28
 
 ### Fixed

--- a/lib/timber/events/error.rb
+++ b/lib/timber/events/error.rb
@@ -8,7 +8,6 @@ module Timber
     # @note This event should be installed automatically through integrations,
     #   such as the {Integrations::ActionDispatch::DebugExceptions} integration.
     class Error < Timber::Event
-      BACKTRACE_JSON_MAX_BYTES = 8192.freeze
       MESSAGE_MAX_BYTES = 8192.freeze
 
       attr_reader :name, :error_message, :backtrace
@@ -18,13 +17,17 @@ module Timber
         @name = normalizer.fetch!(:name, :string)
         @error_message = normalizer.fetch(:error_message, :string, :limit => MESSAGE_MAX_BYTES)
         @backtrace = normalizer.fetch(:backtrace, :array)
+
+        if !backtrace.nil? && backtrace != []
+          @backtrace = backtrace[0..19].collect { |line| parse_backtrace_line(line) }
+        end
       end
 
       def to_hash
         @to_hash ||= Util::NonNilHashBuilder.build do |h|
           h.add(:name, name)
           h.add(:message, error_message)
-          h.add(:backtrace_json, backtrace, :json_encode => true, :limit => BACKTRACE_JSON_MAX_BYTES)
+          h.add(:backtrace, backtrace)
         end
       end
       alias to_h to_hash
@@ -43,6 +46,26 @@ module Timber
 
         message
       end
+
+      private
+        def parse_backtrace_line(line)
+          # using split for performance reasons
+          file, line, function_part = line.split(":", 3)
+
+          parsed_line = {file: file}
+
+          if line
+            parsed_line[:line] = line.to_i
+          end
+
+          if function_part
+            _prefix, function_pre = function_part.split("`", 2)
+            function = Util::Object.try(function_pre, :chomp, "'")
+            parsed_line[:function] = function
+          end
+
+          parsed_line
+        end
     end
   end
 end

--- a/lib/timber/logger.rb
+++ b/lib/timber/logger.rb
@@ -41,16 +41,8 @@ module Timber
             LogEntry.new(level, time, progname, logged_obj.message, context_snapshot, logged_obj,
               tags: tags)
           elsif logged_obj.is_a?(Hash)
-            # Extract the tags
-            tags = tags.clone
-            tags.push(logged_obj.delete(:tag)) if logged_obj.key?(:tag)
-            tags.concat(logged_obj.delete(:tags)) if logged_obj.key?(:tags)
-            tags.uniq!
-
-            # Build the event
             event = Events.build(logged_obj)
             message = event ? event.message : logged_obj[:message]
-
             LogEntry.new(level, time, progname, message, context_snapshot, event, tags: tags)
           else
             LogEntry.new(level, time, progname, logged_obj, context_snapshot, nil, tags: tags)

--- a/lib/timber/overrides/active_support_tagged_logging.rb
+++ b/lib/timber/overrides/active_support_tagged_logging.rb
@@ -2,7 +2,7 @@
 # work properly if ActiveSupport::TaggedLogging is used.
 #
 # This is called after 'active_support_3_tagged_logging' where the constant is loaded and
-# replaced. I want to make sure we don't attempt to load it again undoing the patches
+# replaced. We want to make sure we don't attempt to load it again undoing the patches
 # applied there.
 if defined?(ActiveSupport::TaggedLogging)
   module Timber
@@ -18,7 +18,7 @@ if defined?(ActiveSupport::TaggedLogging)
 
               def call(severity, timestamp, progname, msg)
                 if is_a?(Timber::Logger::Formatter)
-                  # Don't convert the message into a string
+                  # Don't convert the message into a string since the message is an object.
                   super(severity, timestamp, progname, msg)
                 else
                   super(severity, timestamp, progname, "#{tags_text}#{msg}")
@@ -42,6 +42,7 @@ if defined?(ActiveSupport::TaggedLogging)
                   end
                 end
                 if @logger.is_a?(Timber::Logger)
+                  # Don't convert the mesasge into a string since the message is an object.
                   @logger.add(severity, message, progname)
                 else
                   @logger.add(severity, "#{tags_text}#{message}", progname)

--- a/lib/timber/overrides/rails_stdout_logging.rb
+++ b/lib/timber/overrides/rails_stdout_logging.rb
@@ -1,7 +1,8 @@
 # See https://github.com/heroku/rails_stdout_logging
-# I have no idea why this library was created, but most Heroku / Rails apps use it.
-# This library completely obliterates any logger configuration you set.
-# So this patch fixes that.
+# I have no idea why this library was created, because logging to STDOUT is 1 line of code.
+# This library completely obliterates any logger configuration you set by replacing
+# your logging with a logger that writes to STDOUT. We disable this because Timber explicitly
+# sets your logging in your environment configuration files.
 
 begin
   require "rails_stdout_logging"

--- a/lib/timber/util.rb
+++ b/lib/timber/util.rb
@@ -2,6 +2,7 @@ require "timber/util/active_support_log_subscriber"
 require "timber/util/attribute_normalizer"
 require "timber/util/hash"
 require "timber/util/non_nil_hash_builder"
+require "timber/util/object"
 require "timber/util/request"
 require "timber/util/struct"
 

--- a/lib/timber/util/object.rb
+++ b/lib/timber/util/object.rb
@@ -1,0 +1,15 @@
+module Timber
+  module Util
+    # @private
+    module Object
+      # @private
+      def self.try(object, method, *args)
+        if object == nil
+          nil
+        else
+          object.send(method, *args) rescue object
+        end
+      end
+    end
+  end
+end

--- a/spec/rails/tagged_logging_spec.rb
+++ b/spec/rails/tagged_logging_spec.rb
@@ -31,7 +31,7 @@ if defined?(::ActiveSupport::TaggedLogging)
         logger.tagged("tag") do
           logger.info(event)
         end
-        expect(io.string).to include("\"tags\":[\"tag\"]")
+        expect(io.string).to start_with("[tag] select *")
       end
 
       it "should accept events as the second argument" do

--- a/spec/timber/events/error_spec.rb
+++ b/spec/timber/events/error_spec.rb
@@ -12,7 +12,7 @@ describe Timber::Events::Error, :rails_23 => true do
       expected_hash = {
         :name => "RuntimeError",
         :message => "Boom",
-        :backtrace_json => "[\"/path/to/file1.rb:26:in `function1'\",\"path/to/file2.rb:86:in `function2'\"]"
+        :backtrace => [{:file=>"/path/to/file1.rb", :line=>26, :function=>"function1"}, {:file=>"path/to/file2.rb", :line=>86, :function=>"function2"}]
       }
       expect(exception_event.to_hash).to eq(expected_hash)
     end

--- a/spec/timber/events_spec.rb
+++ b/spec/timber/events_spec.rb
@@ -36,6 +36,16 @@ describe Timber::Events, :rails_23 => true do
       expect(built_event.message).to eq("Payment rejected")
     end
 
+    it "should reject a hash without a hash value" do
+      built_event = Timber::Events.build({message: "Payment rejected", key: "value"})
+      expect(built_event).to be_nil
+    end
+
+    it "should reject a hash without multiple keys" do
+      built_event = Timber::Events.build({message: "Payment rejected", key1: {data: "value"}, key2: {data: "value"}})
+      expect(built_event).to be_nil
+    end
+
     it "should accept a struct" do
       PaymentRejectedEvent = Struct.new(:customer_id, :amount) do
         def message; "Payment rejected for #{customer_id}"; end

--- a/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
+++ b/spec/timber/integrations/action_dispatch/debug_exceptions_spec.rb
@@ -41,7 +41,7 @@ if defined?(::ActionDispatch)
         lines = clean_lines(io.string.split("\n"))
         expect(lines.length).to eq(3)
         expect(lines[2]).to start_with('RuntimeError (boom) @metadata {"level":"fatal",')
-        expect(lines[2]).to include("\"event\":{\"error\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace_json\":\"[")
+        expect(lines[2]).to include("\"event\":{\"error\":{\"name\":\"RuntimeError\",\"message\":\"boom\",\"backtrace\":[")
       end
 
       # Remove blank lines since Rails does this to space out requests in the logs

--- a/spec/timber/logger_spec.rb
+++ b/spec/timber/logger_spec.rb
@@ -130,20 +130,6 @@ describe Timber::Logger, :rails_23 => true do
         expect(io.string).to include("\"event\":{\"sql_query\":{\"sql\":\"select * from users\",\"time_ms\":56.0}}")
       end
 
-      it "should allow :tag" do
-        logger.info("event complete", tag: "tag1")
-        expect(io.string).to include("\"tags\":[\"tag1\"]")
-      end
-
-      it "should allow :tags" do
-        tags = ["tag1", "tag2"]
-        logger.info("event complete", tags: tags)
-        expect(io.string).to include("\"tags\":[\"tag1\",\"tag2\"]")
-
-        # Ensure the tags object is not modified
-        expect(tags).to eq(["tag1", "tag2"])
-      end
-
       it "should allow functions" do
         logger.info do
           {message: "payment rejected", payment_rejected: {customer_id: "abcde1234", amount: 100}}
@@ -185,13 +171,6 @@ describe Timber::Logger, :rails_23 => true do
       expect(io.string).to start_with("message @metadata")
       expect(io.string).to include('"level":"error"')
     end
-
-    it "should allow messages with options" do
-      logger.error("message", tag: "tag")
-      expect(io.string).to start_with("message @metadata")
-      expect(io.string).to include('"level":"error"')
-      expect(io.string).to include('"tags":["tag"]')
-    end
   end
 
   describe "#formatter=" do
@@ -217,13 +196,6 @@ describe Timber::Logger, :rails_23 => true do
       logger.info("message")
       expect(io.string).to start_with("message @metadata")
       expect(io.string).to include('"level":"info"')
-    end
-
-    it "should allow messages with options" do
-      logger.info("message", tag: "tag")
-      expect(io.string).to start_with("message @metadata")
-      expect(io.string).to include('"level":"info"')
-      expect(io.string).to include('"tags":["tag"]')
     end
 
     it "should accept non-string messages" do


### PR DESCRIPTION
Rails tagged logging default behavior has been preserved. Previously Timber would strip Rails logging tags and place them in the `tags` key. This is no longer the case and tags will function just as they would without Timber by prefixing your messages with tags. We strongly encourage disabling tags and using the available Timber API for logging structured data (please see the examples in the README).