### PR TITLE
Don't cut out nested hashes from parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
   - Fixes an issue where logging without specifying data would raise an error
+  - Fix nested hash in parameters not showing up in logs
 
 ## [2.6.1] - 2017-11-28
 

--- a/lib/timber/util/hash.rb
+++ b/lib/timber/util/hash.rb
@@ -83,7 +83,7 @@ module Timber
         # We use is_a? because it accounts for inheritance.
         def is_a_primitive_type?(v)
           v.is_a?(Array) || v.is_a?(Integer) || v.is_a?(Float) || v.is_a?(TrueClass) ||
-            v.is_a?(FalseClass) || v.is_a?(String) || v.is_a?(Time)
+            v.is_a?(FalseClass) || v.is_a?(String) || v.is_a?(Time) || v.is_a?(::Hash)
         end
     end
   end

--- a/spec/timber/util/hash_spec.rb
+++ b/spec/timber/util/hash_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Timber::Util::Hash, :rails_23 => true do
+  describe "jsonify" do
+    it "should return the original for simple 1 level hash" do
+      original = { a: "a", b: 1, c: 123.11 }
+      v = jsonify(original)
+      expect(v).to eq(original)
+    end
+
+    it "should return the original when it's a multilevel hash but with supported values" do
+      original = { a: "a", nested: { b: 1 } }
+      v = jsonify(original)
+      expect(v).to eq(original)
+    end
+
+    it "cuts out ASCII strings longer than 1000 characters from the hash" do
+      file1 = ("a" * 1005).encode("ASCII-8BIT")
+      file2 = ("x" * 1010).encode("ASCII-8BIT")
+      original = { path: "abc", file: file1, nested: { path: "def", file: file2 } }
+      v = jsonify(original)
+      expect(v).to eq({ path: "abc", nested: { path: "def" } })
+    end
+
+    def jsonify(h)
+      Timber::Util::Hash.jsonify(h)
+    end
+  end
+
+end


### PR DESCRIPTION
I noticed that whenever the parameters of my request would be something
along the lines of:

```
{
  user_id: 124,
  post: { title: "My Post", body: "This is really awesome" }
}
```

I would end only seeing logs with:

```
{
  user_id: 124
}
```

And the entire post was left somewhere in the dark. It turns out that
the jsonify method was not retaining nested hashes.