### PR TITLE
Re-add CurrentContext.with

### DIFF
--- a/spec/timber/current_context_spec.rb
+++ b/spec/timber/current_context_spec.rb
@@ -89,4 +89,25 @@ describe Timber::CurrentContext do
       expect(described_class.instance.send(:hash)[:build]).to be_nil
     end
   end
+
+  describe ".with" do
+    it "should merge the context and cleanup on block exit" do
+      expect(described_class.instance.send(:hash)[:build]).to be_nil
+
+      described_class.with({build: {version: "1.0.0"}}) do
+        expect(described_class.instance.send(:hash)[:build]).to eq({:version=>"1.0.0"})
+
+        described_class.with({testing: {key: "value"}}) do
+          expect(described_class.instance.send(:hash)[:build]).to eq({:version=>"1.0.0"})
+          expect(described_class.instance.send(:hash)[:testing]).to eq({:key=>"value"})
+        end
+
+        expect(described_class.instance.send(:hash)[:build]).to eq({:version=>"1.0.0"})
+        expect(described_class.instance.send(:hash)[:testing]).to be_nil
+      end
+
+      expect(described_class.instance.send(:hash)[:build]).to be_nil
+      expect(described_class.instance.send(:hash)[:testing]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This re-adds the `CurrentContext.with` method that was accidentally removed due to compatibility issues with the new API. This PR fixes that.

Closes https://github.com/timberio/timber-ruby/issues/204