### PR TITLE
Expose progname in logs

### DIFF
--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -45,9 +45,12 @@ module Timber
       hash = {
         :level => level,
         :dt => formatted_dt,
-        :progname => progname,
         :message => message
       }
+
+      if !progname.nil? && progname.length > 0
+        hash[:progname] = progname
+      end
 
       if !tags.nil? && tags.length > 0
         hash[:tags] = tags

--- a/lib/timber/log_entry.rb
+++ b/lib/timber/log_entry.rb
@@ -45,6 +45,7 @@ module Timber
       hash = {
         :level => level,
         :dt => formatted_dt,
+        :progname => progname,
         :message => message
       }
 

--- a/spec/timber/log_entry_spec.rb
+++ b/spec/timber/log_entry_spec.rb
@@ -14,9 +14,9 @@ describe Timber::LogEntry do
         }
       }
       context = {custom: {a: "b"}}
-      log_entry = described_class.new("INFO", time, nil, "log message", context, event)
+      log_entry = described_class.new("INFO", time, "progname", "log message", context, event)
       msgpack = log_entry.to_msgpack
-      expect(msgpack).to start_with("\x85\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z".force_encoding("ASCII-8BIT"))
+      expect(msgpack).to start_with("\x86\xA5level\xA4INFO\xA2dt\xBB2016-09-01T12:00:00.000000Z\xA8progname\xA8progname".force_encoding("ASCII-8BIT"))
     end
   end
 end


### PR DESCRIPTION
This is feature exists in the native logger.  It'd be great if this is supported by the library as well.